### PR TITLE
fix: Only consider positive mining time when estimating queue time

### DIFF
--- a/tests/manager.py
+++ b/tests/manager.py
@@ -552,3 +552,34 @@ class ManagerTestCase(unittest.TestCase):
         self._run_all_pending_events()
         self.assertTrue(conn.current_job.is_block)
         self.assertEqual(0, conn.current_job.height)
+
+    def test_no_miners_at_start(self):
+        job1 = MinerTxJob(TX1_DATA)
+        self.assertTrue(self.manager.add_job(job1))
+        self.assertEqual(-1, job1.expected_mining_time)
+        self.assertEqual(0, job1.expected_queue_time)
+        self.assertEqual(1, len(self.manager.tx_queue))
+
+        job2 = MinerTxJob(TX2_DATA)
+        self.assertTrue(self.manager.add_job(job2))
+        self.assertEqual(-1, job2.expected_mining_time)
+        self.assertEqual(0, job2.expected_queue_time)
+        self.assertEqual(2, len(self.manager.tx_queue))
+
+        job3 = MinerTxJob(TOKEN_CREATION_TX_DATA)
+        self.assertTrue(self.manager.add_job(job3))
+        self.assertEqual(-1, job3.expected_mining_time)
+        self.assertEqual(0, job3.expected_queue_time)
+        self.assertEqual(3, len(self.manager.tx_queue))
+
+        self.assertEqual([job1, job2, job3], list(self.manager.tx_queue))
+
+        # First miner connects and receives job1.
+        conn1 = self._get_ready_miner('HVZjvL1FJ23kH3buGNuttVRsRKq66WHUVZ')
+        self.assertIsNotNone(conn1.current_job)
+        self.assertEqual(job1, conn1.current_job)
+
+        # Second miner connects and receives job1.
+        conn2 = self._get_ready_miner('HVZjvL1FJ23kH3buGNuttVRsRKq66WHUVZ')
+        self.assertIsNotNone(conn2.current_job)
+        self.assertEqual(job1, conn2.current_job)

--- a/txstratum/manager.py
+++ b/txstratum/manager.py
@@ -237,7 +237,9 @@ class TxMiningManager:
         """Enqueue a tx job to be mined."""
         assert job not in self.tx_queue
         job.status = JobStatus.ENQUEUED
-        job.expected_queue_time = sum(x.expected_mining_time for x in self.tx_queue)
+        # When the total hashrate is unknown, `expected_mining_time` is set to -1. Thus, we need to
+        # skip negative values when calculating the `expected_queue_time`.
+        job.expected_queue_time = sum(x.expected_mining_time for x in self.tx_queue if x.expected_mining_time > 0)
         self.tx_queue.append(job)
 
         if job.timeout:


### PR DESCRIPTION
When a transaction is received to be mined, the tx mining service estimates how long it will take to get it done and saves it to `job.expected_mining_time`. If this time cannot be calculated, this value is set to `-1`.

Finally, when there's a queue of transactions, we sum the individual `expected_mining_time` of the transactions to calculate the `job.expected_queue_time`. In this case, we must ignore the transactions with `-1` value.

We found out this bug when many transactions had `expected_mining_time = -1` and new transactions were summing and setting the `expected_queue_time` to negative values (e.g., -7, -9, -17).