### PR TITLE
fix: Estimate tx-mining-time when the total hashrate of the miners is unknown

### DIFF
--- a/tests/manager.py
+++ b/tests/manager.py
@@ -584,22 +584,32 @@ class ManagerTestCase(unittest.TestCase):
         self.assertEqual(0, conn.current_job.height)
 
     def test_no_miners_at_start(self):
+        from txstratum.constants import DEFAULT_EXPECTED_MINING_TIME
+
+        expected_queue_time = 0
+
         job1 = MinerTxJob(TX1_DATA)
         self.assertTrue(self.manager.add_job(job1))
-        self.assertEqual(-1, job1.expected_mining_time)
+        self.assertEqual(DEFAULT_EXPECTED_MINING_TIME, job1.expected_mining_time)
         self.assertEqual(0, job1.expected_queue_time)
         self.assertEqual(1, len(self.manager.tx_queue))
 
+        if DEFAULT_EXPECTED_MINING_TIME > 0:
+            expected_queue_time += DEFAULT_EXPECTED_MINING_TIME
+
         job2 = MinerTxJob(TX2_DATA)
         self.assertTrue(self.manager.add_job(job2))
-        self.assertEqual(-1, job2.expected_mining_time)
-        self.assertEqual(0, job2.expected_queue_time)
+        self.assertEqual(DEFAULT_EXPECTED_MINING_TIME, job2.expected_mining_time)
+        self.assertEqual(expected_queue_time, job2.expected_queue_time)
         self.assertEqual(2, len(self.manager.tx_queue))
+
+        if DEFAULT_EXPECTED_MINING_TIME > 0:
+            expected_queue_time += DEFAULT_EXPECTED_MINING_TIME
 
         job3 = MinerTxJob(TOKEN_CREATION_TX_DATA)
         self.assertTrue(self.manager.add_job(job3))
-        self.assertEqual(-1, job3.expected_mining_time)
-        self.assertEqual(0, job3.expected_queue_time)
+        self.assertEqual(DEFAULT_EXPECTED_MINING_TIME, job3.expected_mining_time)
+        self.assertEqual(expected_queue_time, job3.expected_queue_time)
         self.assertEqual(3, len(self.manager.tx_queue))
 
         self.assertEqual([job1, job2, job3], list(self.manager.tx_queue))

--- a/txstratum/constants.py
+++ b/txstratum/constants.py
@@ -1,0 +1,18 @@
+# Copyright (c) Hathor Labs and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Default expected mining time when there is no miners or the total hashrate is unknown.
+#
+# We used to return `-1`. In this case, the wallets show an error message saying that
+# "No miners are available".
+#
+# We had an issue when there was a high demand for transaction mining and we restarted
+# the tx-mining-service. In this case, all miners will reconnect and their hashrate will
+# be unknown. At the same time, several transactions will arrive and will have expected_mining_time = -1.
+# In this case, the wallets will show an error message saying that "No miners are available"
+# while the tx mining service will actually solve these transactions.
+#
+# To fix this issue, we set a positive value for the default expected mining time.
+DEFAULT_EXPECTED_MINING_TIME: float = 5.0

--- a/txstratum/utils.py
+++ b/txstratum/utils.py
@@ -11,6 +11,8 @@ from typing import TYPE_CHECKING, Any, Awaitable, Callable, Dict, Generic, Optio
 
 from structlog import get_logger
 
+from txstratum.constants import DEFAULT_EXPECTED_MINING_TIME
+
 if TYPE_CHECKING:
     from txstratum.commons import BaseTransaction
 
@@ -317,7 +319,10 @@ def calculate_expected_mining_time(miners_hashrate_ghs: float, job_weight: float
       5  | 0.9932
     """
     if miners_hashrate_ghs == 0:
-        return -1
+        # What happens when there is no miners or we don't know the total hashrate?
+        # We return a default expected mining time. For further information, see the
+        # docstring of the constant.
+        return DEFAULT_EXPECTED_MINING_TIME
     return 3 * (2**(job_weight - 30)) / miners_hashrate_ghs
 
 


### PR DESCRIPTION
When a miner connects to the tx mining service, its hashrate is unknown and it will be discovered after a few iterations in the difficulty adjustment loop. Usually it takes ~30 seconds to find a reasonable estimate for the hashrate.

Currently, when the total hashrate of the miners is unknown, we set the `job.expected_mining_time` to `-1`.

This pull request intends to fix a problem that happens when several transactions are arriving to be mined and we restart the tx mining service. In this case, all miners will reconnect and their hashrate will be unknown. At the same time, several transactions will arrive and will have `expected_mining_time = -1`. In this case, the wallets will show an error message saying that "No miners are available" while the tx mining service will actually solve these transactions.

Besides that, as transactions have priority over blocks, miners will receive tx jobs (instead of block jobs) and the difficulty adjustment loop skip tx jobs. It brings a situation in which we never discover the hashrate of the miners and hence we cannot estimate the mining time of new transactions. As users keep receiving the "No miners are available" error message, they usually try again and we get the same transaction over and over.

The proposed change is currently in use by the tx mining service connected to our mainnet. It sets a fixed estimate for the mining time of transactions when the hashrate is unknown. So, the wallets won't show the error message and will work correctly. After the queue is empty, the tx mining service will send block jobs to the miners and the discovery process will work correctly.