### PR TITLE
feat(backend): Backend's get_block_template must give an address for the block

### DIFF
--- a/tests/api.py
+++ b/tests/api.py
@@ -39,7 +39,7 @@ TOKEN_CREATION_TX_NONCE = '01ff7369'
 
 class AppTestCase(AioHTTPTestCase):
     async def get_application(self):
-        self.manager = TxMiningManager(backend=None)
+        self.manager = TxMiningManager(backend=None, address=None)
         app = App(self.manager)
         return app.app
 

--- a/tests/prometheus.py
+++ b/tests/prometheus.py
@@ -15,7 +15,7 @@ from txstratum.prometheus import METRIC_INFO, MetricData, PrometheusExporter
 
 class ManagerTestCase(unittest.TestCase):
     def setUp(self):
-        self.manager = TxMiningManager(backend=None)
+        self.manager = TxMiningManager(backend=None, address=None)
         self.tmpdir = tempfile.mkdtemp()
 
     def tearDown(self):

--- a/txstratum/cli.py
+++ b/txstratum/cli.py
@@ -26,6 +26,7 @@ def create_parser() -> ArgumentParser:
     parser.add_argument('--tx-timeout', help='Tx mining timeout (seconds)', type=int, default=None)
     parser.add_argument('--prometheus', help='Path to export metrics for Prometheus', type=str, default=None)
     parser.add_argument('--testnet', action='store_true', help='Use testnet config parameters')
+    parser.add_argument('--address', help='Mining address for blocks', type=str, default=None)
     parser.add_argument('backend', help='Endpoint of the Hathor API (without version)', type=str)
     return parser
 
@@ -52,7 +53,8 @@ def execute(args: Namespace) -> None:
 
     backend = HathorClient(args.backend)
     manager = TxMiningManager(
-        backend=backend
+        backend=backend,
+        address=args.address,
     )
     loop.run_until_complete(backend.start())
     loop.run_until_complete(manager.start())

--- a/txstratum/commons/client.py
+++ b/txstratum/commons/client.py
@@ -73,10 +73,13 @@ class HathorClient:
             major, minor, patch = ver.split('.')
             return HathorVersion(int(major), int(minor), int(patch))
 
-    async def get_block_template(self) -> BlockTemplate:
+    async def get_block_template(self, address: Optional[str] = None) -> BlockTemplate:
         """Return a block template."""
         assert self._session is not None
-        async with self._session.get(self._get_url('get_block_template')) as resp:
+        params = {}
+        if address is not None:
+            params['address'] = address
+        async with self._session.get(self._get_url('get_block_template'), params=params) as resp:
             data = await resp.json()
 
             if data.get('error'):

--- a/txstratum/commons/exceptions.py
+++ b/txstratum/commons/exceptions.py
@@ -19,6 +19,10 @@ class HathorError(Exception):
     """General error class"""
 
 
+class InvalidAddress(HathorError):
+    """Address is invalid"""
+
+
 class TxValidationError(HathorError):
     """Base class for tx validation errors"""
 

--- a/txstratum/commons/utils.py
+++ b/txstratum/commons/utils.py
@@ -12,6 +12,7 @@ from typing import Any, Tuple
 import base58
 
 from txstratum.commons.conf import HathorSettings
+from txstratum.commons.exceptions import InvalidAddress
 
 settings = HathorSettings()
 
@@ -27,10 +28,6 @@ def unpack(fmt: str, buf: bytes) -> Any:
 
 def unpack_len(n: int, buf: bytes) -> Tuple[bytes, bytes]:
     return buf[:n], buf[n:]
-
-
-class InvalidAddress(Exception):
-    """Raised when decoding an invalid address."""
 
 
 def get_checksum(address_bytes: bytes) -> bytes:

--- a/txstratum/protocol.py
+++ b/txstratum/protocol.py
@@ -11,7 +11,8 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, NamedTuple, Optiona
 from structlog import get_logger
 
 from txstratum.commons import sum_weights
-from txstratum.commons.utils import InvalidAddress, decode_address
+from txstratum.commons.exceptions import InvalidAddress
+from txstratum.commons.utils import decode_address
 from txstratum.jobs import MinerBlockJob
 from txstratum.utils import JSONRPCError, JSONRPCId, JSONRPCProtocol, MaxSizeOrderedDict, Periodic
 


### PR DESCRIPTION
It doesn't make sense to mine blocks without an output, and to generate an output we need an address. Even though it is very unlikely that the tx-mining-service will find a block in Hathor's mainnet, it is also used to mine blocks in the testnet where it indeed find many blocks.