### PR TITLE
fix: Fix stale jobs, invalid jobs, and invalid share errors

### DIFF
--- a/txstratum/api.py
+++ b/txstratum/api.py
@@ -11,7 +11,7 @@ from aiohttp import web
 import txstratum.time
 from txstratum.commons import TokenCreationTransaction, Transaction
 from txstratum.commons.exceptions import TxValidationError
-from txstratum.jobs import JobStatus, MinerTxJob
+from txstratum.jobs import JobStatus, TxJob
 from txstratum.utils import tx_or_block_from_bytes
 
 if TYPE_CHECKING:
@@ -104,13 +104,13 @@ class App:
         add_parents = data.get('add_parents', False)
         propagate = data.get('propagate', False)
 
-        job = MinerTxJob(tx_bytes, add_parents=add_parents, propagate=propagate, timeout=timeout)
+        job = TxJob(tx_bytes, add_parents=add_parents, propagate=propagate, timeout=timeout)
         success = self.manager.add_job(job)
         if not success:
             return web.json_response({'error': 'job-already-exists'}, status=400)
         return web.json_response(job.to_dict())
 
-    def _get_job(self, uuid_hex: Optional[str]) -> MinerTxJob:
+    def _get_job(self, uuid_hex: Optional[str]) -> TxJob:
         """Return job from uuid_hex. It raises web exceptions for common issues."""
         if not uuid_hex:
             raise web.HTTPBadRequest(

--- a/txstratum/commons/base_transaction.py
+++ b/txstratum/commons/base_transaction.py
@@ -146,6 +146,14 @@ class BaseTransaction(ABC):
         class_name = type(self).__name__
         return '%s(%s)' % (class_name, ', '.join('%s=%s' % i for i in self._get_formatted_fields_dict().items()))
 
+    def clone(self) -> 'BaseTransaction':
+        """Return exact copy without sharing memory, including metadata if loaded.
+
+        :return: Transaction or Block copy
+        """
+        new_tx = self.create_from_struct(bytes(self))
+        return new_tx
+
     def get_fields_from_struct(self, struct_bytes: bytes) -> bytes:
         """ Gets all common fields for a Transaction and a Block from a buffer.
 


### PR DESCRIPTION
This PR fixes three issues: (i) invalid jobs, (ii) stale jobs, and (iii) invalid shares.

**invalid_jobs**: This issue happened when the weight was an integer number. As the job is a json sent to the miner, the miner had a deserialization problem.

**stale jobs**: This issue happened when mining blocks and either the block's timestamp was updated or the job's share weight changed. As the job's id remained the same, the miner submitted the solution to the old id which had already been marked as resolved.

**invalid shares**: This issue has the same root cause as the stale jobs issue. But, in this case, the job hadn't been marked as resolved and the solution was calculated for a different timestamp.

The solution is to generate a random id for each `MinerJob`. But we need an id for each tx received by the API, so a new class `TxJob` was created. The `TxJob` object represents a tx job received by the API, while the `MinerTxJob` represents a job sent to the miner.

Solves #4 .