### PR TITLE
fix: Log asyncio's unhandled exceptions

### DIFF
--- a/txstratum/cli.py
+++ b/txstratum/cli.py
@@ -39,8 +39,10 @@ def execute(args: Namespace) -> None:
 
     from txstratum.api import App
     from txstratum.manager import TxMiningManager
+    from txstratum.utils import start_logging
 
     # Configure log.
+    start_logging()
     if os.path.exists(args.log_config):
         logging.config.fileConfig(args.log_config)
         from structlog.stdlib import LoggerFactory


### PR DESCRIPTION
Example:

```
2021-03-05 16:06.09 [error    ] Exception in callback TxMiningManager._job_timeout_if_possible(<txstratum.jo...t 0x10a722e50>) handle=<TimerHandle when=10 TxMiningManager._job_timeout_if_possible(<txstratum.jo...t 0x10a722e50>)>
Traceback (most recent call last):
  File "/Users/msbrogli/.pyenv/versions/3.8.2/lib/python3.8/asyncio/events.py", line 81, in _run
    self._context.run(self._callback, *self._args)
  File "/Users/msbrogli/Hathor/tx-mining-service/txstratum/manager.py", line 269, in _job_timeout_if_possible
    raise Exception('Testing')
Exception: Testing
```