### PR TITLE
Fix: exceptions during Tx Mining

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ Or you can use the Docker image
 We also have a public Docker image if you don't want to build it yourself:
     docker run -it --network="host" hathornetwork/tx-mining-service <full-node-address:port> --address <mining-reward-address> --api-port 8080 --stratum-port 8000
 
+### Debug logs
+
+If you need to enable debug logs, you should edit the file `log.conf` and set the log level there.
+
+You could also use a completely different file to configure the logs, by using the parameter `log-config` when running the service.
+
 
 ## How to test?
 

--- a/txstratum/manager.py
+++ b/txstratum/manager.py
@@ -133,7 +133,7 @@ class TxMiningManager:
             assert isinstance(job, MinerTxJob)
             # Remove from queue.
             tx_job = job.tx_job
-            self.log.info(f"Solution submitted for job {tx_job}")
+            self.log.info(f"Solution submitted for TxJob {tx_job}")
             try:
                 self.tx_queue.remove(tx_job)
             except ValueError:


### PR DESCRIPTION
### Acceptance Criteria
- Fix exceptions when 2 miners submit a solution to the same job at the same time
- Fix exception when trying to timeout a job and it is not in the queue anymore

The exceptions being fixed are better described below.

### Important
Those exceptions apparently were greatly affecting the TxMiningService efficiency when receiving too many Txs in a short period of time.

They might be one of the causes for the bottlenecks described in https://github.com/HathorNetwork/internal-issues/issues/63

I ran load tests against this branch and the master to compare the effect this fix would have. The load test consisted in sending 6 txs per second for 20s in a private local network.

With the fix, 89.6% of the Txs were mined and returned to the wallet-headless as successful.

Without the fix, 40,8% were successful.

(Those load tests can be reproduced using the code in https://github.com/HathorNetwork/ops-tools/pull/221. However, a bigger setup of the environment is needed that is not described yet)

### Exceptions
This one occurred when 2 miners submitted a solution to the same job almost at the same time, and the tx job had already been popped from the queue, which them becomes empty.
```
Traceback (most recent call last):
  File "/usr/lib/python3.6/asyncio/events.py", line 145, in _run
    self._callback(*self._args)
  File "/usr/lib/python3.6/asyncio/selector_events.py", line 721, in _read_ready
    self._protocol.data_received(data)
  File "/home/ubuntu/tx-mining-service/txstratum/utils.py", line 114, in data_received
    self.line_received(line)
  File "/home/ubuntu/tx-mining-service/txstratum/utils.py", line 155, in line_received
    self.json_received(data)
  File "/home/ubuntu/tx-mining-service/txstratum/utils.py", line 159, in json_received
    if self.try_as_request(data):
  File "/home/ubuntu/tx-mining-service/txstratum/utils.py", line 175, in try_as_request
    self.handle_request(method, params, msgid)
  File "/home/ubuntu/tx-mining-service/txstratum/utils.py", line 208, in handle_request
    fn(params, msgid)
  File "/home/ubuntu/tx-mining-service/txstratum/protocol.py", line 230, in method_submit
    self.manager.submit_solution(self, job, obj.get_struct_nonce())
  File "/home/ubuntu/tx-mining-service/txstratum/manager.py", line 136, in submit_solution
    tx_job2 = self.tx_queue.popleft()
IndexError: pop from an empty deque
```

This is almost the same situation as the exception above, with the different that the queue is not empty. Instead, a job different from the expected is popped because the right job had already been popped by the other submission.

```
Traceback (most recent call last):
  File "/usr/lib/python3.6/asyncio/events.py", line 145, in _run
    self._callback(*self._args)
  File "/usr/lib/python3.6/asyncio/selector_events.py", line 721, in _read_ready
    self._protocol.data_received(data)
  File "/home/ubuntu/tx-mining-service/txstratum/utils.py", line 114, in data_received
    self.line_received(line)
  File "/home/ubuntu/tx-mining-service/txstratum/utils.py", line 155, in line_received
    self.json_received(data)
  File "/home/ubuntu/tx-mining-service/txstratum/utils.py", line 159, in json_received
    if self.try_as_request(data):
  File "/home/ubuntu/tx-mining-service/txstratum/utils.py", line 175, in try_as_request
    self.handle_request(method, params, msgid)
  File "/home/ubuntu/tx-mining-service/txstratum/utils.py", line 208, in handle_request
    fn(params, msgid)
  File "/home/ubuntu/tx-mining-service/txstratum/protocol.py", line 230, in method_submit
    self.manager.submit_solution(self, job, obj.get_struct_nonce())
  File "/home/ubuntu/tx-mining-service/txstratum/manager.py", line 137, in submit_solution
    assert tx_job is tx_job2
AssertionError
```

This one happened when trying to timeout a job that was not in queue anymore. The cause is similar to the others. A miner might submit a solution just before the timeout was triggered.

```
Traceback (most recent call last):
  File "/home/luislhl/.pyenv/versions/3.8.3/lib/python3.8/asyncio/events.py", line 81, in _run
    self._context.run(self._callback, *self._args)
  File "/home/luislhl/Workspace/hathor/tx-mining-service/txstratum/manager.py", line 267, in _job_timeout_if_possible
    self.tx_queue.remove(job)
ValueError: deque.remove(x): x not in deque
```
