### PR TITLE
ci: push images to ECR

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,8 +4,8 @@ on:
     tags:
     - v*
     # TODO: Remove
-    # branches:
-    # - ci/push-to-ecr
+    branches:
+    - ci/push-to-ecr
 
 jobs:
   # push-to-dockerhub:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,9 +3,7 @@ on:
   push:
     tags:
     - v*
-    # TODO: Remove
     branches:
-    - ci/push-to-ecr
     - master
 
 jobs:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,8 +3,35 @@ on:
   push:
     tags:
     - v*
+    # TODO: Remove
+    # branches:
+    # - ci/push-to-ecr
+
 jobs:
-  build:
+  # push-to-dockerhub:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #   - name: Set output
+  #     id: vars
+  #     run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
+  #   - name: Set up QEMU
+  #     uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480
+  #   - name: Set up Docker Buildx
+  #     uses: docker/setup-buildx-action@94ab11c41e45d028884a99163086648e898eed25
+  #   - name: Login to DockerHub
+  #     uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+  #     with:
+  #       username: ${{ secrets.DOCKERHUB_USERNAME }}
+  #       password: ${{ secrets.DOCKERHUB_TOKEN }}
+  #   - name: Build and push
+  #     uses: docker/build-push-action@a66e35b9cbcf4ad0ea91ffcaf7bbad63ad9e0229
+  #     with:
+  #       push: true
+  #       tags: hathornetwork/tx-mining-service:latest,hathornetwork/tx-mining-service:${{ steps.vars.outputs.tag }}
+  #       platforms: linux/amd64,linux/arm64
+  #       cache-from: type=gha
+  #       cache-to: type=gha,mode=max
+  push-to-ecr:
     runs-on: ubuntu-latest
     steps:
     - name: Set output
@@ -14,16 +41,17 @@ jobs:
       uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@94ab11c41e45d028884a99163086648e898eed25
-    - name: Login to DockerHub
+    - name: Login to AWS ECR
       uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
       with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.eu-central-1.amazonaws.com
+          username: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     - name: Build and push
       uses: docker/build-push-action@a66e35b9cbcf4ad0ea91ffcaf7bbad63ad9e0229
       with:
         push: true
-        tags: hathornetwork/tx-mining-service:latest,hathornetwork/tx-mining-service:${{ steps.vars.outputs.tag }}
+        tags: ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.eu-central-1.amazonaws.com/tx-mining-service:latest,${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.eu-central-1.amazonaws.com/tx-mining-service:${{ steps.vars.outputs.tag }}
         platforms: linux/amd64,linux/arm64
         cache-from: type=gha
         cache-to: type=gha,mode=max

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -42,7 +42,7 @@ jobs:
       run: |
         import datetime
 
-        timestamp = int(datetime.datetime.now().timestamp())
+        timestamp = str(int(datetime.datetime.now().timestamp()))
         base_tag = '${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.eu-central-1.amazonaws.com/tx-mining-service'
 
         tags = {}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,37 +6,59 @@ on:
     # TODO: Remove
     branches:
     - ci/push-to-ecr
+    - master
 
 jobs:
-  # push-to-dockerhub:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #   - name: Set output
-  #     id: vars
-  #     run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
-  #   - name: Set up QEMU
-  #     uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480
-  #   - name: Set up Docker Buildx
-  #     uses: docker/setup-buildx-action@94ab11c41e45d028884a99163086648e898eed25
-  #   - name: Login to DockerHub
-  #     uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
-  #     with:
-  #       username: ${{ secrets.DOCKERHUB_USERNAME }}
-  #       password: ${{ secrets.DOCKERHUB_TOKEN }}
-  #   - name: Build and push
-  #     uses: docker/build-push-action@a66e35b9cbcf4ad0ea91ffcaf7bbad63ad9e0229
-  #     with:
-  #       push: true
-  #       tags: hathornetwork/tx-mining-service:latest,hathornetwork/tx-mining-service:${{ steps.vars.outputs.tag }}
-  #       platforms: linux/amd64,linux/arm64
-  #       cache-from: type=gha
-  #       cache-to: type=gha,mode=max
-  push-to-ecr:
+  push-to-dockerhub:
+    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
     - name: Set output
-      id: vars
+      id: tags
       run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@94ab11c41e45d028884a99163086648e898eed25
+    - name: Login to DockerHub
+      uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+    - name: Build and push
+      uses: docker/build-push-action@a66e35b9cbcf4ad0ea91ffcaf7bbad63ad9e0229
+      with:
+        push: true
+        tags: hathornetwork/tx-mining-service:latest,hathornetwork/tx-mining-service:${{ steps.tags.outputs.tag }}
+        platforms: linux/amd64,linux/arm64
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+  push-to-ecr:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Prepare tags
+      id: tags
+      shell: python
+      run: |
+        import datetime
+
+        timestamp = int(datetime.datetime.now().timestamp())
+        base_tag = '${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.eu-central-1.amazonaws.com/tx-mining-service'
+
+        tags = {}
+
+        ref = '${{ github.ref }}'
+        if ref.startswith('refs/tags/'):
+            tag = ref[10:].split('-', 1)[0]
+
+            tags.add(base_tag + ':latest')
+        elif ref == 'refs/heads/master':
+            tag = 'staging-${{ github.sha }}-' + timestamp
+        else:
+            tag = 'dev-${{ github.sha }}-' + timestamp
+
+        tags.add(base_tag + ':' + tag)
+        print("::set-output name=tags::" + tags)
     - name: Set up QEMU
       uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480
     - name: Set up Docker Buildx
@@ -51,7 +73,7 @@ jobs:
       uses: docker/build-push-action@a66e35b9cbcf4ad0ea91ffcaf7bbad63ad9e0229
       with:
         push: true
-        tags: ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.eu-central-1.amazonaws.com/tx-mining-service:latest,${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.eu-central-1.amazonaws.com/tx-mining-service:${{ steps.vars.outputs.tag }}
+        tags: ${{ steps.tags.outputs.tags }}
         platforms: linux/amd64,linux/arm64
         cache-from: type=gha
         cache-to: type=gha,mode=max

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -45,7 +45,7 @@ jobs:
         timestamp = str(int(datetime.datetime.now().timestamp()))
         base_tag = '${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.eu-central-1.amazonaws.com/tx-mining-service'
 
-        tags = {}
+        tags = set()
 
         ref = '${{ github.ref }}'
         if ref.startswith('refs/tags/'):

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -35,7 +35,7 @@ jobs:
             tags.add(base_dockerhub_tag + version)
             tags.add(base_dockerhub_tag + 'latest')
         elif ref == 'refs/heads/master':
-            tags.add(base_ecr_tag + 'staging-${{ github.sha }}-' + timestamp
+            tags.add(base_ecr_tag + 'staging-${{ github.sha }}-' + timestamp)
         else:
             tags.add(base_ecr_tag + 'dev-${{ github.sha }}-' + timestamp)
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,31 +9,8 @@ on:
     - master
 
 jobs:
-  push-to-dockerhub:
-    if: startsWith(github.ref, 'refs/tags/v')
-    runs-on: ubuntu-latest
-    steps:
-    - name: Set output
-      id: tags
-      run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@94ab11c41e45d028884a99163086648e898eed25
-    - name: Login to DockerHub
-      uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
-      with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
-    - name: Build and push
-      uses: docker/build-push-action@a66e35b9cbcf4ad0ea91ffcaf7bbad63ad9e0229
-      with:
-        push: true
-        tags: hathornetwork/tx-mining-service:latest,hathornetwork/tx-mining-service:${{ steps.tags.outputs.tag }}
-        platforms: linux/amd64,linux/arm64
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
-  push-to-ecr:
+  # Builds and pushes the Docker image to Docker Hub and ECR
+  push-to-registries:
     runs-on: ubuntu-latest
     steps:
     - name: Prepare tags
@@ -43,26 +20,35 @@ jobs:
         import datetime
 
         timestamp = str(int(datetime.datetime.now().timestamp()))
-        base_tag = '${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.eu-central-1.amazonaws.com/tx-mining-service'
+        base_ecr_tag = '${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.eu-central-1.amazonaws.com/tx-mining-service:'
+        base_dockerhub_tag = 'hathornetwork/tx-mining-service:'
 
         tags = set()
 
         ref = '${{ github.ref }}'
         if ref.startswith('refs/tags/'):
-            tag = ref[10:].split('-', 1)[0]
+            version = ref[10:].split('-', 1)[0]
 
-            tags.add(base_tag + ':latest')
+            tags.add(base_ecr_tag + version)
+            tags.add(base_ecr_tag + 'latest')
+
+            tags.add(base_dockerhub_tag + version)
+            tags.add(base_dockerhub_tag + 'latest')
         elif ref == 'refs/heads/master':
-            tag = 'staging-${{ github.sha }}-' + timestamp
+            tags.add(base_ecr_tag + 'staging-${{ github.sha }}-' + timestamp
         else:
-            tag = 'dev-${{ github.sha }}-' + timestamp
+            tags.add(base_ecr_tag + 'dev-${{ github.sha }}-' + timestamp)
 
-        tags.add(base_tag + ':' + tag)
         print("::set-output name=tags::" + ",".join(tags))
     - name: Set up QEMU
       uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@94ab11c41e45d028884a99163086648e898eed25
+    - name: Login to DockerHub
+      uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
     - name: Login to AWS ECR
       uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
       with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,8 +18,8 @@ jobs:
         import datetime
 
         timestamp = str(int(datetime.datetime.now().timestamp()))
-        base_ecr_tag = '${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.eu-central-1.amazonaws.com/tx-mining-service:'
-        base_dockerhub_tag = 'hathornetwork/tx-mining-service:'
+        base_ecr_tag = '${{ secrets.AWS_ECR_URL }}:'
+        base_dockerhub_tag = 'docker.io/hathornetwork/tx-mining-service:'
 
         tags = set()
 
@@ -50,7 +50,7 @@ jobs:
     - name: Login to AWS ECR
       uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
       with:
-          registry: ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.eu-central-1.amazonaws.com
+          registry: ${{ secrets.AWS_ECR_URL}}
           username: ${{ secrets.AWS_ACCESS_KEY_ID }}
           password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     - name: Build and push

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -58,7 +58,7 @@ jobs:
             tag = 'dev-${{ github.sha }}-' + timestamp
 
         tags.add(base_tag + ':' + tag)
-        print("::set-output name=tags::" + tags)
+        print("::set-output name=tags::" + ",".join(tags))
     - name: Set up QEMU
       uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480
     - name: Set up Docker Buildx


### PR DESCRIPTION
### Acceptance Criteria
- We should push images to ECR with tags of `dev-*`, `staging-*`, and `v*`. `staging-*` on commits to  `master`, `v*` when tags are created, and `dev-*` in any other case.
- We should only push images with tags `v*` to Dockerhub

### Motivation
We will be deploying a new instance of tx-mining-service that will use those images from ECR.