### PR TITLE
fix: store the mining start time in the jobs

### DIFF
--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -633,6 +633,42 @@ class ManagerTestCase(unittest.TestCase):
         self.assertIsNotNone(conn2.current_job)
         self.assertEqual(job1, conn2.current_job.tx_job)
 
+    def test_miner_block_submission_after_receiving_tx(self):
+        """
+        Simulates a miner that submits a block even after receiving a tx to mine.
+
+        This is something we observed in the wild.
+        """
+        # Motivated by the exception in https://github.com/HathorNetwork/tx-mining-service/pull/52
+
+        conn = self._get_ready_miner()
+        self.assertIsNotNone(conn.current_job)
+        self.assertTrue(conn.current_job.is_block)
+        self.assertEqual(0, conn.current_job.height)
+
+        block_job = conn.current_job
+
+        # Receive a tx to mine
+        job1 = TxJob(TX1_DATA)
+        ret1 = self.manager.add_job(job1)
+        self.assertFalse(conn.current_job.is_block)
+        self.assertEqual(conn.current_job.tx_job, job1)
+        self.assertTrue(ret1)
+
+        # Submit a block, even though we just received a tx to mine
+        params = {
+            'job_id': block_job.uuid.hex(),
+            'nonce': '00000000000000000000000000278a7e',
+        }
+
+        conn.send_error = MagicMock(return_value=None)
+        conn.send_result = MagicMock(return_value=None)
+        conn.method_submit(params=params, msgid=None)
+        conn.send_error.assert_not_called()
+        conn.send_result.assert_called_once_with(None, 'ok')
+
+        # Make sure the block submission was received
+        self.assertEqual(len(conn._submitted_work), 1)
 
 class ManagerClockedTestCase(asynctest.ClockedTestCase):  # type: ignore
     def setUp(self):

--- a/txstratum/jobs.py
+++ b/txstratum/jobs.py
@@ -144,6 +144,7 @@ class MinerJob(ABC):
     uuid: bytes
     is_block: bool
     share_weight: float
+    started_at: Optional[float]
     submitted_at: Optional[float]
 
     @abstractmethod
@@ -191,6 +192,7 @@ class MinerTxJob(MinerJob):
         self.is_block: bool = False
         self.share_weight: float = 0
         self.created_at: float = txstratum.time.time()
+        self.started_at: Optional[float] = None
         self.submitted_at: Optional[float] = None
 
     def get_object(self) -> BaseTransaction:
@@ -230,6 +232,7 @@ class MinerBlockJob(MinerJob):
         self.is_block: bool = True
         self.share_weight: float = 0
         self.created_at: float = txstratum.time.time()
+        self.started_at: Optional[float] = None
         self.submitted_at: Optional[float] = None
 
     def get_data(self) -> bytes:

--- a/txstratum/protocol.py
+++ b/txstratum/protocol.py
@@ -226,6 +226,7 @@ class StratumProtocol(JSONRPCProtocol):
         self.send_result(msgid, 'ok')
 
         if isinstance(job, MinerBlockJob):
+            assert job.started_at is not None
             dt = job.submitted_at - job.started_at
             self._submitted_work.append(SubmittedWork(job.submitted_at, job.share_weight, dt))
         # Too many jobs too fast, increase difficulty out of caution (more than 10 submits within the last 10s)


### PR DESCRIPTION
### Acceptance Criteria
- We should stop getting this exception:

```
txstratum.utils - ERROR - 2022-01-12 11:41.38 [error    ] Fatal error: protocol.data_received() call failed. protocol=<txstratum.protocol.StratumProtocol object at 0x7fc5e661f610> transport=<_SelectorSocketTransport fd=9 read=polling write=<idle, bufsize=0>>
Traceback (most recent call last):
  File "/home/luislhl/.pyenv/versions/3.8.3/lib/python3.8/asyncio/selector_events.py", line 860, in _read_ready__data_received
    self._protocol.data_received(data)
  File "/home/luislhl/Workspace/hathor/tx-mining-service/txstratum/utils.py", line 114, in data_received
    self.line_received(line)
  File "/home/luislhl/Workspace/hathor/tx-mining-service/txstratum/utils.py", line 155, in line_received
    self.json_received(data)
  File "/home/luislhl/Workspace/hathor/tx-mining-service/txstratum/utils.py", line 159, in json_received
    if self.try_as_request(data):
  File "/home/luislhl/Workspace/hathor/tx-mining-service/txstratum/utils.py", line 175, in try_as_request
    self.handle_request(method, params, msgid)
  File "/home/luislhl/Workspace/hathor/tx-mining-service/txstratum/utils.py", line 208, in handle_request
    fn(params, msgid)
  File "/home/luislhl/Workspace/hathor/tx-mining-service/txstratum/protocol.py", line 236, in method_submit
    assert self.started_current_block_at is not None
AssertionError

```

### Motivation
The situation here is similar to the ones that generated the exceptions in https://github.com/HathorNetwork/tx-mining-service/pull/38

The miners sometimes submit solutions to jobs that they should have already stopped working on. Probably there is some overhead in changing jobs that causes this.

But some places in our code were assuming this never happens, which generated the exceptions.

In this case, the miner could submit a solution to a block right after being told to start working on a transaction.

When we changed the job to a transaction, we made `self.started_current_block_at = None`. But when the block submission arrived, it ran `assert self.started_current_block_at is not None`, which generated the exception