### PR TITLE
fix: get miner version from cgminers

### DIFF
--- a/txstratum/protocol.py
+++ b/txstratum/protocol.py
@@ -3,7 +3,6 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 import asyncio
-import random
 import uuid
 from math import log2
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, NamedTuple, Optional, cast
@@ -143,7 +142,7 @@ class StratumProtocol(JSONRPCProtocol):
         else:
             self.log.error('Cant handle result: {}'.format(result), miner_id=self.miner_id, msgid=msgid)
 
-    def get_next_message_id(self):
+    def get_next_message_id(self) -> int:
         """Return the next message id."""
         msgid = self.next_message_id
         self.next_message_id += 1

--- a/txstratum/protocol.py
+++ b/txstratum/protocol.py
@@ -120,6 +120,7 @@ class StratumProtocol(JSONRPCProtocol):
         }
 
         self.messages_in_transit: Dict[int, MessageInTransit] = {}
+        self.next_message_id = 1
 
     @property
     def miner_type(self) -> str:
@@ -142,15 +143,15 @@ class StratumProtocol(JSONRPCProtocol):
         else:
             self.log.error('Cant handle result: {}'.format(result), miner_id=self.miner_id, msgid=msgid)
 
+    def get_next_message_id(self):
+        """Return the next message id."""
+        msgid = self.next_message_id
+        self.next_message_id += 1
+        return msgid
+
     def send_and_track_request(self, method: str, params: Any) -> None:
         """Send a request to the client and track it."""
-        assert len(self.messages_in_transit) < 1000000
-
-        msgid = random.randint(1, 1000000)
-
-        # We need to make sure msg ids are unique
-        while msgid in self.messages_in_transit:
-            msgid = random.randint(1, 1000000)
+        msgid = self.get_next_message_id()
 
         self.messages_in_transit[msgid] = MessageInTransit(
             id=msgid,


### PR DESCRIPTION
### Acceptance Criteria
We should be able to get the miner version from cgminers.

Previously we couldn't, because they only accept integers as ids for messages, and we were using a string as id. This is what causes this behavior there: https://github.com/HathorNetwork/cgminer/blob/master/util.c#L2468

To achieve this, his PR implements a better way to manage the messages that are waiting return from the miners.

### Notes
I didn't test this with `ccminer` miners. But we shouldn't have problems since their implementation to handle the `get_version` message is almost the same as the `cpuminer` one. This can be seen in https://github.com/HathorNetwork/ccminer/blob/master/util.cpp#L1683 and https://github.com/HathorNetwork/cpuminer/blob/master/util.c#L1408