### PR TITLE
feat: metrics to detect if miner is up

### DIFF
--- a/txstratum/protocol.py
+++ b/txstratum/protocol.py
@@ -179,6 +179,7 @@ class StratumProtocol(JSONRPCProtocol):
         self.log.debug('connection lost', exc=exc)
         if self._subscribed:
             self.log.info('Miner exited')
+            self.manager.pubsub.emit(TxMiningEvents.PROTOCOL_MINER_DISCONNECTED, self)
         assert self.miner_id is not None
         self.manager.remove_connection(self)
         if self.estimator_task:
@@ -259,6 +260,7 @@ class StratumProtocol(JSONRPCProtocol):
         self._subscribed = True
         self.send_result('ok', msgid)
         self.log.info('Miner subscribed', address=self.miner_address_str)
+        self.manager.pubsub.emit(TxMiningEvents.PROTOCOL_MINER_SUBSCRIBED, self)
         self.start_if_ready()
 
     def method_authorize(self, params: Any, msgid: JSONRPCId) -> None:

--- a/txstratum/pubsub.py
+++ b/txstratum/pubsub.py
@@ -16,6 +16,8 @@ class TxMiningEvents(Enum):
     MANAGER_TX_TIMEOUT = 'manager:tx_timeout'
     MANAGER_NEW_TX_JOB = 'manager:new_tx_job'
     PROTOCOL_JOB_COMPLETED = 'protocol:job_completed'
+    PROTOCOL_MINER_SUBSCRIBED = 'protocol:miner_subcribed'
+    PROTOCOL_MINER_DISCONNECTED = 'protocol:miner_disconnected'
 
 
 class PubSubManager():


### PR DESCRIPTION
### Acceptance Criteria
- We should have a metric `miner_up` in Prometheus with value `1`  if the miner is connected to tx-mining-service, and `0` if it is disconnected

### Notes
This solution requires that we never use the same address in 2 different miners, otherwise we will not be able to differentiate their metrics.

### Motivation
In some cases we need to know if the miner is down to filter them out in Prometheus queries and alerts