### PR TITLE
ci: fix Github Actions job trigger

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,8 +7,6 @@ on:
     tags:
     - v*
   pull_request:
-    types:
-    - synchronize
 jobs:
   test:
     name: python-${{ matrix.python }} (${{ matrix.os }})

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,10 @@ on:
     tags:
     - v*
   pull_request:
+    types:
+    - synchronize
+    - opened
+    - reopened
 jobs:
   test:
     name: python-${{ matrix.python }} (${{ matrix.os }})

--- a/tests/fixtures/expected_prometheus_metrics.prom
+++ b/tests/fixtures/expected_prometheus_metrics.prom
@@ -97,3 +97,5 @@ txs_waiting_time_sum 10.0
 txs_waiting_time_created 1.6425116726168673e+09
 # HELP miner_completed_jobs_total Number of completed jobs by miner
 # TYPE miner_completed_jobs_total counter
+# HELP miner_up Indicates that a miner is up
+# TYPE miner_up gauge


### PR DESCRIPTION
### Acceptance Criteria
Tests should run on PRs that were just opened. We merged a PR with failed tests (https://github.com/HathorNetwork/tx-mining-service/pull/57) because the tests didn't run and nobody noticed.