### PR TITLE
feat: rate limits

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -300,6 +300,24 @@ colors = ["colorama (>=0.4.3,<0.5.0)"]
 plugins = ["setuptools"]
 
 [[package]]
+name = "limits"
+version = "2.3.3"
+description = "Rate limiting utilities"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+all = ["redis (>3,<5.0.0)", "redis-py-cluster (>=2.0.0,<3)", "pymemcache (>3,<4.0.0)", "pymongo (>3,<5)", "coredis[hiredis] (>=2.0.0,<3)", "emcache (>=0.6.1)", "motor (>=2.5,<3)"]
+async-memcached = ["emcache (>=0.6.1)"]
+async-mongodb = ["motor (>=2.5,<3)"]
+async-redis = ["coredis[hiredis] (>=2.0.0,<3)"]
+memcached = ["pymemcache (>3,<4.0.0)"]
+mongodb = ["pymongo (>3,<5)"]
+redis = ["redis (>3,<5.0.0)"]
+rediscluster = ["redis-py-cluster (>=2.0.0,<3)"]
+
+[[package]]
 name = "mccabe"
 version = "0.6.1"
 description = "McCabe checker, plugin for flake8"
@@ -595,7 +613,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7,<4.0"
-content-hash = "18e65d3dc069318afdffbd5214ac2a96b8ad4df7e2a3e1fc9b721e414bd25548"
+content-hash = "0915975e04731cf83c3591c6cb27fa35a6329e3614746bf377e23ce7db611b85"
 
 [metadata.files]
 aiohttp = [
@@ -945,6 +963,10 @@ iniconfig = [
 isort = [
     {file = "isort-5.10.1-py3-none-any.whl", hash = "sha256:6f62d78e2f89b4500b080fe3a81690850cd254227f27f75c3a0c491a1f351ba7"},
     {file = "isort-5.10.1.tar.gz", hash = "sha256:e8443a5e7a020e9d7f97f1d7d9cd17c88bcb3bc7e218bf9cf5095fe550be2951"},
+]
+limits = [
+    {file = "limits-2.3.3-py3-none-any.whl", hash = "sha256:9ead6236a71eb1d9a18d7e3b1faa58d588ea3510e55514fae58babc0a3223986"},
+    {file = "limits-2.3.3.tar.gz", hash = "sha256:d4270d29591cc5eceab19be053455a4e619ba395062502bde2b5681af7dc1be8"},
 ]
 mccabe = [
     {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -191,6 +191,20 @@ ssh = ["bcrypt (>=3.1.5)"]
 test = ["pytest (>=6.2.0)", "pytest-cov", "pytest-subtests", "pytest-xdist", "pretend", "iso8601", "pytz", "hypothesis (>=1.11.4,!=3.79.2)"]
 
 [[package]]
+name = "deprecated"
+version = "1.2.13"
+description = "Python @deprecated decorator to deprecate old python classes, functions or methods."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[package.dependencies]
+wrapt = ">=1.10,<2"
+
+[package.extras]
+dev = ["tox", "bump2version (<1)", "sphinx (<2)", "importlib-metadata (<3)", "importlib-resources (<4)", "configparser (<5)", "sphinxcontrib-websupport (<2)", "zipp (<2)", "PyTest (<5)", "PyTest-Cov (<2.6)", "pytest", "pytest-cov"]
+
+[[package]]
 name = "flake8"
 version = "3.9.2"
 description = "the modular source code checker: pep8 pyflakes and co"
@@ -264,7 +278,7 @@ idna = ">=2.0"
 name = "importlib-metadata"
 version = "4.11.1"
 description = "Read metadata from Python packages"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 
@@ -369,7 +383,7 @@ python-versions = ">=3.7"
 name = "packaging"
 version = "21.3"
 description = "Core utilities for Python packages"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 
@@ -472,7 +486,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 name = "pyparsing"
 version = "3.0.7"
 description = "Python parsing module"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 
@@ -528,6 +542,23 @@ toml = "*"
 
 [package.extras]
 testing = ["fields", "hunter", "process-tests", "six", "pytest-xdist", "virtualenv"]
+
+[[package]]
+name = "redis"
+version = "4.1.4"
+description = "Python client for Redis database and key-value store"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+deprecated = ">=1.2.3"
+importlib-metadata = {version = ">=1.0", markers = "python_version < \"3.8\""}
+packaging = ">=20.4"
+
+[package.extras]
+hiredis = ["hiredis (>=1.0.0)"]
+ocsp = ["cryptography (>=36.0.1)", "pyopenssl (==20.0.1)", "requests (>=2.26.0)"]
 
 [[package]]
 name = "snowballstemmer"
@@ -586,6 +617,14 @@ optional = false
 python-versions = ">=3.6"
 
 [[package]]
+name = "wrapt"
+version = "1.13.3"
+description = "Module for decorators, wrappers and monkey patching."
+category = "main"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+
+[[package]]
 name = "yarl"
 version = "1.7.2"
 description = "Yet another URL library"
@@ -602,7 +641,7 @@ typing-extensions = {version = ">=3.7.4", markers = "python_version < \"3.8\""}
 name = "zipp"
 version = "3.7.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 
@@ -872,6 +911,10 @@ cryptography = [
     {file = "cryptography-36.0.1-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:39bdf8e70eee6b1c7b289ec6e5d84d49a6bfa11f8b8646b5b3dfe41219153316"},
     {file = "cryptography-36.0.1.tar.gz", hash = "sha256:53e5c1dc3d7a953de055d77bef2ff607ceef7a2aac0353b5d630ab67f7423638"},
 ]
+deprecated = [
+    {file = "Deprecated-1.2.13-py2.py3-none-any.whl", hash = "sha256:64756e3e14c8c5eea9795d93c524551432a0be75629f8f29e67ab8caf076c76d"},
+    {file = "Deprecated-1.2.13.tar.gz", hash = "sha256:43ac5335da90c31c24ba028af536a91d41d53f9e6901ddb021bcc572ce44e38d"},
+]
 flake8 = [
     {file = "flake8-3.9.2-py2.py3-none-any.whl", hash = "sha256:bf8fd333346d844f616e8d47905ef3a3384edae6b4e9beb0c5101e25e3110907"},
     {file = "flake8-3.9.2.tar.gz", hash = "sha256:07528381786f2a6237b061f6e96610a4167b226cb926e2aa2b6b1d78057c576b"},
@@ -1139,6 +1182,10 @@ pytest-cov = [
     {file = "pytest-cov-2.12.1.tar.gz", hash = "sha256:261ceeb8c227b726249b376b8526b600f38667ee314f910353fa318caa01f4d7"},
     {file = "pytest_cov-2.12.1-py2.py3-none-any.whl", hash = "sha256:261bb9e47e65bd099c89c3edf92972865210c36813f80ede5277dceb77a4a62a"},
 ]
+redis = [
+    {file = "redis-4.1.4-py3-none-any.whl", hash = "sha256:04629f8e42be942c4f7d1812f2094568f04c612865ad19ad3ace3005da70631a"},
+    {file = "redis-4.1.4.tar.gz", hash = "sha256:1d9a0cdf89fdd93f84261733e24f55a7bbd413a9b219fdaf56e3e728ca9a2306"},
+]
 snowballstemmer = [
     {file = "snowballstemmer-2.2.0-py2.py3-none-any.whl", hash = "sha256:c8e1716e83cc398ae16824e5572ae04e0d9fc2c6b985fb0f900f5f0c96ecba1a"},
     {file = "snowballstemmer-2.2.0.tar.gz", hash = "sha256:09b16deb8547d3412ad7b590689584cd0fe25ec8db3be37788be3810cbf19cb1"},
@@ -1190,6 +1237,59 @@ typed-ast = [
 typing-extensions = [
     {file = "typing_extensions-4.1.1-py3-none-any.whl", hash = "sha256:21c85e0fe4b9a155d0799430b0ad741cdce7e359660ccbd8b530613e8df88ce2"},
     {file = "typing_extensions-4.1.1.tar.gz", hash = "sha256:1a9462dcc3347a79b1f1c0271fbe79e844580bb598bafa1ed208b94da3cdcd42"},
+]
+wrapt = [
+    {file = "wrapt-1.13.3-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:e05e60ff3b2b0342153be4d1b597bbcfd8330890056b9619f4ad6b8d5c96a81a"},
+    {file = "wrapt-1.13.3-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:85148f4225287b6a0665eef08a178c15097366d46b210574a658c1ff5b377489"},
+    {file = "wrapt-1.13.3-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:2dded5496e8f1592ec27079b28b6ad2a1ef0b9296d270f77b8e4a3a796cf6909"},
+    {file = "wrapt-1.13.3-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:e94b7d9deaa4cc7bac9198a58a7240aaf87fe56c6277ee25fa5b3aa1edebd229"},
+    {file = "wrapt-1.13.3-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:498e6217523111d07cd67e87a791f5e9ee769f9241fcf8a379696e25806965af"},
+    {file = "wrapt-1.13.3-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:ec7e20258ecc5174029a0f391e1b948bf2906cd64c198a9b8b281b811cbc04de"},
+    {file = "wrapt-1.13.3-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:87883690cae293541e08ba2da22cacaae0a092e0ed56bbba8d018cc486fbafbb"},
+    {file = "wrapt-1.13.3-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:f99c0489258086308aad4ae57da9e8ecf9e1f3f30fa35d5e170b4d4896554d80"},
+    {file = "wrapt-1.13.3-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:6a03d9917aee887690aa3f1747ce634e610f6db6f6b332b35c2dd89412912bca"},
+    {file = "wrapt-1.13.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:936503cb0a6ed28dbfa87e8fcd0a56458822144e9d11a49ccee6d9a8adb2ac44"},
+    {file = "wrapt-1.13.3-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:f9c51d9af9abb899bd34ace878fbec8bf357b3194a10c4e8e0a25512826ef056"},
+    {file = "wrapt-1.13.3-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:220a869982ea9023e163ba915077816ca439489de6d2c09089b219f4e11b6785"},
+    {file = "wrapt-1.13.3-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:0877fe981fd76b183711d767500e6b3111378ed2043c145e21816ee589d91096"},
+    {file = "wrapt-1.13.3-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:43e69ffe47e3609a6aec0fe723001c60c65305784d964f5007d5b4fb1bc6bf33"},
+    {file = "wrapt-1.13.3-cp310-cp310-win32.whl", hash = "sha256:78dea98c81915bbf510eb6a3c9c24915e4660302937b9ae05a0947164248020f"},
+    {file = "wrapt-1.13.3-cp310-cp310-win_amd64.whl", hash = "sha256:ea3e746e29d4000cd98d572f3ee2a6050a4f784bb536f4ac1f035987fc1ed83e"},
+    {file = "wrapt-1.13.3-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:8c73c1a2ec7c98d7eaded149f6d225a692caa1bd7b2401a14125446e9e90410d"},
+    {file = "wrapt-1.13.3-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:086218a72ec7d986a3eddb7707c8c4526d677c7b35e355875a0fe2918b059179"},
+    {file = "wrapt-1.13.3-cp35-cp35m-manylinux2010_i686.whl", hash = "sha256:e92d0d4fa68ea0c02d39f1e2f9cb5bc4b4a71e8c442207433d8db47ee79d7aa3"},
+    {file = "wrapt-1.13.3-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:d4a5f6146cfa5c7ba0134249665acd322a70d1ea61732723c7d3e8cc0fa80755"},
+    {file = "wrapt-1.13.3-cp35-cp35m-win32.whl", hash = "sha256:8aab36778fa9bba1a8f06a4919556f9f8c7b33102bd71b3ab307bb3fecb21851"},
+    {file = "wrapt-1.13.3-cp35-cp35m-win_amd64.whl", hash = "sha256:944b180f61f5e36c0634d3202ba8509b986b5fbaf57db3e94df11abee244ba13"},
+    {file = "wrapt-1.13.3-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:2ebdde19cd3c8cdf8df3fc165bc7827334bc4e353465048b36f7deeae8ee0918"},
+    {file = "wrapt-1.13.3-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:610f5f83dd1e0ad40254c306f4764fcdc846641f120c3cf424ff57a19d5f7ade"},
+    {file = "wrapt-1.13.3-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:5601f44a0f38fed36cc07db004f0eedeaadbdcec90e4e90509480e7e6060a5bc"},
+    {file = "wrapt-1.13.3-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:e6906d6f48437dfd80464f7d7af1740eadc572b9f7a4301e7dd3d65db285cacf"},
+    {file = "wrapt-1.13.3-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:766b32c762e07e26f50d8a3468e3b4228b3736c805018e4b0ec8cc01ecd88125"},
+    {file = "wrapt-1.13.3-cp36-cp36m-win32.whl", hash = "sha256:5f223101f21cfd41deec8ce3889dc59f88a59b409db028c469c9b20cfeefbe36"},
+    {file = "wrapt-1.13.3-cp36-cp36m-win_amd64.whl", hash = "sha256:f122ccd12fdc69628786d0c947bdd9cb2733be8f800d88b5a37c57f1f1d73c10"},
+    {file = "wrapt-1.13.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:46f7f3af321a573fc0c3586612db4decb7eb37172af1bc6173d81f5b66c2e068"},
+    {file = "wrapt-1.13.3-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:778fd096ee96890c10ce96187c76b3e99b2da44e08c9e24d5652f356873f6709"},
+    {file = "wrapt-1.13.3-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:0cb23d36ed03bf46b894cfec777eec754146d68429c30431c99ef28482b5c1df"},
+    {file = "wrapt-1.13.3-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:96b81ae75591a795d8c90edc0bfaab44d3d41ffc1aae4d994c5aa21d9b8e19a2"},
+    {file = "wrapt-1.13.3-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:7dd215e4e8514004c8d810a73e342c536547038fb130205ec4bba9f5de35d45b"},
+    {file = "wrapt-1.13.3-cp37-cp37m-win32.whl", hash = "sha256:47f0a183743e7f71f29e4e21574ad3fa95676136f45b91afcf83f6a050914829"},
+    {file = "wrapt-1.13.3-cp37-cp37m-win_amd64.whl", hash = "sha256:fd76c47f20984b43d93de9a82011bb6e5f8325df6c9ed4d8310029a55fa361ea"},
+    {file = "wrapt-1.13.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:b73d4b78807bd299b38e4598b8e7bd34ed55d480160d2e7fdaabd9931afa65f9"},
+    {file = "wrapt-1.13.3-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:ec9465dd69d5657b5d2fa6133b3e1e989ae27d29471a672416fd729b429eb554"},
+    {file = "wrapt-1.13.3-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:dd91006848eb55af2159375134d724032a2d1d13bcc6f81cd8d3ed9f2b8e846c"},
+    {file = "wrapt-1.13.3-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:ae9de71eb60940e58207f8e71fe113c639da42adb02fb2bcbcaccc1ccecd092b"},
+    {file = "wrapt-1.13.3-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:51799ca950cfee9396a87f4a1240622ac38973b6df5ef7a41e7f0b98797099ce"},
+    {file = "wrapt-1.13.3-cp38-cp38-win32.whl", hash = "sha256:4b9c458732450ec42578b5642ac53e312092acf8c0bfce140ada5ca1ac556f79"},
+    {file = "wrapt-1.13.3-cp38-cp38-win_amd64.whl", hash = "sha256:7dde79d007cd6dfa65afe404766057c2409316135cb892be4b1c768e3f3a11cb"},
+    {file = "wrapt-1.13.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:981da26722bebb9247a0601e2922cedf8bb7a600e89c852d063313102de6f2cb"},
+    {file = "wrapt-1.13.3-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:705e2af1f7be4707e49ced9153f8d72131090e52be9278b5dbb1498c749a1e32"},
+    {file = "wrapt-1.13.3-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:25b1b1d5df495d82be1c9d2fad408f7ce5ca8a38085e2da41bb63c914baadff7"},
+    {file = "wrapt-1.13.3-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:77416e6b17926d953b5c666a3cb718d5945df63ecf922af0ee576206d7033b5e"},
+    {file = "wrapt-1.13.3-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:865c0b50003616f05858b22174c40ffc27a38e67359fa1495605f96125f76640"},
+    {file = "wrapt-1.13.3-cp39-cp39-win32.whl", hash = "sha256:0a017a667d1f7411816e4bf214646d0ad5b1da2c1ea13dec6c162736ff25a374"},
+    {file = "wrapt-1.13.3-cp39-cp39-win_amd64.whl", hash = "sha256:81bd7c90d28a4b2e1df135bfbd7c23aee3050078ca6441bead44c42483f9ebfb"},
+    {file = "wrapt-1.13.3.tar.gz", hash = "sha256:1fea9cd438686e6682271d36f3481a9f3636195578bab9ca3382e2f5f01fc185"},
 ]
 yarl = [
     {file = "yarl-1.7.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:f2a8508f7350512434e41065684076f640ecce176d262a7d54f0da41d99c5a95"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ idna_ssl = "^1.1.0"
 asynctest = "^0.13.0"
 hathorlib = {version = "^0.1.1", extras = ["client"]}
 dataclasses = {version = "^0.8", python = ">=3.6,<3.7"}
+limits = "^2.3.3"
 
 [tool.poetry.dev-dependencies]
 flake8 = "^3.8.4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ asynctest = "^0.13.0"
 hathorlib = {version = "^0.1.1", extras = ["client"]}
 dataclasses = {version = "^0.8", python = ">=3.6,<3.7"}
 limits = "^2.3.3"
+redis = "^4.1.4"
 
 [tool.poetry.dev-dependencies]
 flake8 = "^3.8.4"

--- a/tests/test_rate_limiter.py
+++ b/tests/test_rate_limiter.py
@@ -1,0 +1,66 @@
+from asyncore import loop
+
+import asynctest
+from aiohttp import web
+from aiohttp.test_utils import (
+    AioHTTPTestCase,
+    TestClient,
+    TestServer,
+    unittest_run_loop,
+)
+
+from txstratum.rate_limiter import MemoryLimiter, get_default_keyfunc
+
+limiter = MemoryLimiter()
+
+
+class FakeApp:
+    def __init__(self):
+        self.app = web.Application()
+        self.app.router.add_get("/route", self.route)
+
+    @limiter.limit(keyfunc=get_default_keyfunc("1/3"))
+    def route(self, request: web.Request) -> web.Response:
+        return web.json_response({"success": True})
+
+
+class RateLimiterTestCase(asynctest.ClockedTestCase):
+    def setUp(self):
+        from tests.utils import Clock
+
+        self.clock = Clock(self.loop)
+        self.clock.enable()
+
+        self.app = FakeApp().app
+        self.server = TestServer(self.app, loop=self.loop)
+        self.client = TestClient(self.server, loop=self.loop)
+
+        self.loop.run_until_complete(self.client.start_server())
+
+    def tearDown(self):
+        self.loop.run_until_complete(self.client.close())
+
+        self.clock.disable()
+
+    async def test_rate_limit(self):
+        # First call should be allowed
+        resp = await self.client.request("GET", "/route")
+        assert resp.status == 200
+        data = await resp.json()
+        self.assertTrue(data["success"])
+
+        # Second call should be rate limited
+        resp = await self.client.request("GET", "/route")
+        assert resp.status == 429
+        data = await resp.json()
+        self.assertEqual(data["error"], "Rate limit exceeded: 1 per 3 second")
+
+        # TODO How to make time pass?
+
+        # # Third call should be allowed after 3 seconds
+        # await self.advance(3)
+
+        # resp = await self.client.request('GET', '/route')
+        # assert resp.status == 200
+        # data = await resp.json()
+        # self.assertTrue(data['success'])

--- a/txstratum/api.py
+++ b/txstratum/api.py
@@ -10,6 +10,7 @@ from aiohttp import web
 from hathorlib import TokenCreationTransaction, Transaction
 from hathorlib.exceptions import TxValidationError
 from structlog import get_logger
+from txstratum.rate_limiter import Limiter, get_default_keyfunc
 
 import txstratum.time
 from txstratum.exceptions import JobAlreadyExists, NewJobRefused
@@ -35,6 +36,8 @@ MAX_TIMESTAMP_DELTA: int = 300
 TX_TIMEOUT: float = 20.0
 
 logger = get_logger()
+
+limiter = Limiter()
 
 
 class App:
@@ -75,6 +78,7 @@ class App:
         """Return that the service is running."""
         return web.json_response({"success": True})
 
+    @limiter.limit(keyfunc=get_default_keyfunc("1/3"))
     async def mining_status(self, request: web.Request) -> web.Response:
         """Return status of miners."""
         return web.json_response(self.manager.status())

--- a/txstratum/api.py
+++ b/txstratum/api.py
@@ -4,7 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import json
-from typing import TYPE_CHECKING, Coroutine, List, Optional
+from typing import TYPE_CHECKING, Any, Awaitable, Callable, Coroutine, List, Optional
 
 from aiohttp import web
 from hathorlib import TokenCreationTransaction, Transaction
@@ -93,7 +93,17 @@ class App:
 
         self.fix_invalid_timestamp: bool = fix_invalid_timestamp
 
-    def rate_limit_wrapper(self, func: Coroutine, rate_limit: str) -> web.Response:
+    def rate_limit_wrapper(
+        self,
+        func: Callable[[web.Request], Coroutine[Any, Any, web.Response]],
+        rate_limit: str,
+    ) -> Callable[[web.Request], Awaitable[web.StreamResponse]]:
+        """Wrap one of the app routes with rate limiting.
+
+        :param func: The route to wrap.
+        :param rate_limit: The rate limit to apply.
+        :return: The wrapped route.
+        """
         if not self.rate_limiter:
             return func
 

--- a/txstratum/cli.py
+++ b/txstratum/cli.py
@@ -19,7 +19,7 @@ from txstratum.api import App
 from txstratum.filters import FileFilter, TOIFilter, TXFilter
 from txstratum.manager import TxMiningManager
 from txstratum.pubsub import PubSubManager
-from txstratum.rate_limiter import MemoryLimiter, RedisLimiter
+from txstratum.rate_limiter import MemoryLimiter, RateLimiter, RedisLimiter
 from txstratum.toi_client import TOIAsyncClient
 
 logger = get_logger()
@@ -159,6 +159,8 @@ class RunService:
             pubsub=self.pubsub,
             address=args.address,
         )
+
+        self.rate_limiter: Optional[RateLimiter] = None
 
     def configure_logging(self, args: Namespace) -> None:
         """Configure logging."""

--- a/txstratum/rate_limiter.py
+++ b/txstratum/rate_limiter.py
@@ -4,18 +4,50 @@ import asyncio
 import json
 from abc import ABC, abstractmethod
 from functools import wraps
-from typing import Awaitable, Callable, Optional, Tuple, Type, Union
+from typing import Awaitable, Callable, Dict, Optional, Tuple
 
 import limits.strategies
 from aiohttp.web import Request, Response
-from limits.storage import MemoryStorage, RedisStorage, Storage
+from limits.storage import MemoryStorage, RedisStorage
 
 
-def get_default_keyfunc(ratelimit: str) -> Callable[[str], str]:
+class Allow:
+    """This class can be used by custom error handlers passed to the rate limiter to allow the request to continue."""
+
+    def __init__(self) -> None:  # noqa: D107
+        pass
+
+
+class RateLimitExceeded:
+    """This class is used to pass the details of a rate limit exceeded error to the error handler."""
+
+    def __init__(self, detail: str) -> None:  # noqa: D107
+        self._detail = detail
+
+    @property
+    def detail(self) -> str:  # noqa: D102
+        return self._detail
+
+
+# Type aliases
+keyfunc_type = Callable[[Request], Tuple[str, str]]
+func_type = Callable[[Request], Awaitable[Response]]
+error_handler_type = Optional[
+    Callable[[Request, RateLimitExceeded], Awaitable[Response]]
+]
+wrapper_type = Callable[[Request], Awaitable[Response]]
+
+
+def get_default_keyfunc(ratelimit: str) -> keyfunc_type:
+    """
+    Return the default keyfunc to be used with the rate limiter.
+
+    The keyfunc is used by the rate limiter to determine the key and rate limit to apply to a request.
+
+    The default keyfunc uses the user's IP as key and the same rate limit for all IPs.
+    """
+
     def keyfunc(request: Request) -> Tuple[str, str]:
-        """
-        Returns the user's IP as key and the same rate limit for all IPs.
-        """
         ip = request.headers.get("X-Forwarded-For") or request.remote or "127.0.0.1"
         ip = ip.split(",")[0]
         return ip, ratelimit
@@ -23,75 +55,60 @@ def get_default_keyfunc(ratelimit: str) -> Callable[[str], str]:
     return keyfunc
 
 
-class Allow:
-    def __init__(self) -> None:
-        pass
-
-
-class RateLimitExceeded:
-    def __init__(self, detail: str) -> None:
-        self._detail = detail
-
-    @property
-    def detail(self):
-        return self._detail
-
-
 class BaseRateLimitDecorator:
-    """
-    Decorator to rate limit requests in the aiohttp.web framework
-    """
+    """Decorator to rate limit requests in the aiohttp.web framework."""
 
     def __init__(
         self,
-        db: Storage,
-        path_id: str,
+        path_id: Optional[str],
         moving_window: limits.strategies.MovingWindowRateLimiter,
-        keyfunc: Callable,
-        error_handler: Optional[Union[Callable, Awaitable]] = None,
+        keyfunc: keyfunc_type,
+        error_handler: error_handler_type = None,
     ) -> None:
+        """Init method.
+
+        :param path_id: This is included in the key. Usually the path of the request is passed here.
+        :param moving_window: The rate limiting moving window to use. It should have been initialized with the storage.
+        :param keyfunc: The keyfunc to use for the rate limiter.
+            It is used to determine the key and rate limit to apply to a request.
+        :param error_handler: Custom error handler, defaults to None
+        """
         self.keyfunc = keyfunc
         self.error_handler = error_handler
-        self.db = db
         self.path_id = path_id
         self.moving_window = moving_window
-        self.items = {}
+        self.items: Dict[str, limits.RateLimitItem] = {}
 
     def create_or_get_item(self, key: str, ratelimit: str) -> limits.RateLimitItem:
+        """Create a new rate limit item if it does not exist and returns it.
+
+        :param key: The key to use for the rate limit item.
+        :param ratelimit: The rate limit to use for the rate limit item.
+        :return: The rate limit item.
+        """
         if key in self.items:
             return self.items[key]
 
-        calls, period = ratelimit.split("/")
-        calls = int(calls)
-        period = int(period)
+        c, p = ratelimit.split("/")
+        calls = int(c)
+        period = int(p)
+
         assert period > 0
         assert calls > 0
 
-        if period >= 31_536_000:
-            item = limits.RateLimitItemPerYear(calls, period / 31_536_000)
-        elif period >= 2_628_000:
-            item = limits.RateLimitItemPerMonth(calls, period / 2_628_000)
-        elif period >= 86400:
-            item = limits.RateLimitItemPerDay(calls, period / 86400)
-        elif period >= 3600:
-            item = limits.RateLimitItemPerHour(calls, period / 3600)
-        elif period >= 60:
-            item = limits.RateLimitItemPerMinute(calls, period / 60)
-        else:
-            item = limits.RateLimitItemPerSecond(calls, period)
+        item = limits.RateLimitItemPerSecond(calls, period)
 
         self.items[key] = item
 
         return item
 
-    def get_item_for_key(self, key: str) -> limits.RateLimitItem:
-        if not key in self.items:
-            # TODO Issue a warning about this?
-            return self.items["default"]
+    def __call__(self, func: func_type) -> wrapper_type:
+        """Wrap an aiohttp route function to apply the rate limiting.
 
-        return self.items[key]
+        :param func: The function to wrap.
+        :return: The wrapped function.
+        """
 
-    def __call__(self, func: Callable) -> Awaitable:
         @wraps(func)
         async def wrapper(request: Request) -> Response:
             key, ratelimit = self.keyfunc(request)
@@ -99,29 +116,21 @@ class BaseRateLimitDecorator:
 
             item = self.create_or_get_item(db_key, ratelimit)
 
-            if isinstance(self.db, MemoryStorage):
-                if not self.db.check():
-                    self.db.reset()
-
             assert asyncio.iscoroutinefunction(func), "func must be a coroutine"
 
             # Returns a response if the number of calls exceeds the max amount of calls
             if not self.moving_window.test(item, db_key):
                 if self.error_handler is not None:
-                    if asyncio.iscoroutinefunction(self.error_handler):
-                        r = await self.error_handler(
-                            request, RateLimitExceeded(**{"detail": str(item)})
-                        )
-                        if isinstance(r, Allow):
-                            return await func(request)
-                        return r
-                    else:
-                        r = self.error_handler(
-                            request, RateLimitExceeded(**{"detail": str(item)})
-                        )
-                        if isinstance(r, Allow):
-                            return await func(request)
-                        return r
+                    assert asyncio.iscoroutinefunction(
+                        self.error_handler
+                    ), "error_handler must be a coroutine"
+
+                    r = await self.error_handler(
+                        request, RateLimitExceeded(**{"detail": str(item)})
+                    )
+                    if isinstance(r, Allow):
+                        return await func(request)
+                    return r
                 data = json.dumps({"error": f"Rate limit exceeded: {item}"})
                 response = Response(
                     text=data, content_type="application/json", status=429
@@ -137,18 +146,30 @@ class BaseRateLimitDecorator:
 
 
 class RateLimiter(ABC):
+    """Interface for rate limiter implementations."""
+
     @abstractmethod
     def limit(
         self,
-        keyfunc: Callable,
-        error_handler: Optional[Union[Callable, Awaitable]],
-        path_id: Optional[str],
-    ) -> Callable:
+        keyfunc: keyfunc_type,
+        error_handler: error_handler_type = None,
+        path_id: Optional[str] = None,
+    ) -> Callable[[func_type], wrapper_type]:
+        """Return a decorator to be used in aiohttp.web routes.
+
+        :param keyfunc: The keyfunc to use for the rate limiter.
+            It is used to determine the key and rate limit to apply to a request.
+        :param error_handler: Custom error handler, defaults to None
+        :param path_id: This is included in the key. Usually the path of the request is passed here.
+        :return: The decorator.
+        """
         raise NotImplementedError
 
 
 class MemoryLimiter(RateLimiter):
-    """
+    """Rate Limiter class that uses Memory as storage.
+
+    Example usage:
     ```
     limiter = MemoryLimiter(keyfunc=your_keyfunc)
 
@@ -159,26 +180,39 @@ class MemoryLimiter(RateLimiter):
     ```
     """
 
-    def __init__(
-        self, error_handler: Optional[Union[Callable, Awaitable]] = None
-    ) -> None:
+    def __init__(self, error_handler: error_handler_type = None) -> None:
+        """Initilize the MemoryLimiter.
+
+        :param error_handler: Custom error handler, defaults to None
+        """
         self.error_handler = error_handler
         self.db = MemoryStorage()
         self.moving_window = limits.strategies.MovingWindowRateLimiter(self.db)
 
+        if not self.db.check():
+            self.db.reset()  # type: ignore[no-untyped-call]
+
     def limit(
         self,
-        keyfunc: Callable,
-        error_handler: Optional[Union[Callable, Awaitable]] = None,
-        path_id: str = None,
-    ) -> Callable:
-        def wrapper(func: Callable) -> Awaitable:
+        keyfunc: keyfunc_type,
+        error_handler: error_handler_type = None,
+        path_id: Optional[str] = None,
+    ) -> Callable[[func_type], wrapper_type]:
+        """Return a decorator to be used in aiohttp.web routes.
+
+        :param keyfunc: The keyfunc to use for the rate limiter.
+            It is used to determine the key and rate limit to apply to a request.
+        :param error_handler: Custom error handler, defaults to None
+        :param path_id: This is included in the key. Usually the path of the request is passed here.
+        :return: The decorator.
+        """
+
+        def wrapper(func: func_type) -> wrapper_type:
             _error_handler = self.error_handler or error_handler
 
             return BaseRateLimitDecorator(
                 keyfunc=keyfunc,
                 error_handler=_error_handler,
-                db=self.db,
                 path_id=path_id,
                 moving_window=self.moving_window,
             )(func)
@@ -187,7 +221,8 @@ class MemoryLimiter(RateLimiter):
 
 
 class RedisLimiter(RateLimiter):
-    """
+    """Rate Limter class that uses Redis as storage.
+
     ```
     limiter = RedisLimiter(keyfunc=your_keyfunc, uri="redis://username:password@host:port")
     @routes.get("/")
@@ -197,24 +232,35 @@ class RedisLimiter(RateLimiter):
     ```
     """
 
-    def __init__(
-        self, uri: str, error_handler: Optional[Union[Callable, Awaitable]] = None
-    ) -> None:
+    def __init__(self, uri: str, error_handler: error_handler_type = None) -> None:
+        """Initilize the RedisLimiter.
+
+        :param uri: The URI to connect to the redis server.
+        :param error_handler: Custom error handler, defaults to None
+        """
         self.db = RedisStorage(uri=uri)
         self.moving_window = limits.strategies.MovingWindowRateLimiter(self.db)
         self.error_handler = error_handler
 
     def limit(
         self,
-        keyfunc: Callable = None,
-        error_handler: Optional[Union[Callable, Awaitable]] = None,
-        path_id: str = None,
-    ) -> Callable:
-        def wrapper(func: Callable) -> Awaitable:
+        keyfunc: keyfunc_type,
+        error_handler: error_handler_type = None,
+        path_id: Optional[str] = None,
+    ) -> Callable[[func_type], wrapper_type]:
+        """Return a decorator to be used in aiohttp.web routes.
+
+        :param keyfunc: The keyfunc to use for the rate limiter.
+            It is used to determine the key and rate limit to apply to a request.
+        :param error_handler: Custom error handler, defaults to None
+        :param path_id: This is included in the key. Usually the path of the request is passed here.
+        :return: The decorator.
+        """
+
+        def wrapper(func: func_type) -> wrapper_type:
             _error_handler = self.error_handler or error_handler
 
             return BaseRateLimitDecorator(
-                db=self.db,
                 keyfunc=keyfunc,
                 error_handler=_error_handler,
                 path_id=path_id,

--- a/txstratum/rate_limiter.py
+++ b/txstratum/rate_limiter.py
@@ -1,0 +1,187 @@
+from functools import wraps
+import json
+from typing import Callable, Awaitable, Tuple, Union, Optional
+import asyncio
+from aiohttp.web import Request, Response
+from limits.storage import MemoryStorage
+import limits.strategies
+
+
+def get_default_keyfunc(ratelimit: str) -> Callable[[str], str]:
+    def keyfunc(request: Request) -> Tuple[str, str]:
+        """
+        Returns the user's IP
+        """
+        ip = request.headers.get(
+            "X-Forwarded-For") or request.remote or "127.0.0.1"
+        ip = ip.split(",")[0]
+        return ip, ratelimit 
+
+    return keyfunc
+
+
+class Allow:
+    def __init__(self) -> None:
+        pass
+
+
+class RateLimitExceeded:
+    def __init__(self, detail: str) -> None:
+        self._detail = detail
+
+    @property
+    def detail(self):
+        return self._detail
+
+
+class RateLimitDecorator:
+    """
+    Decorator to rate limit requests in the aiohttp.web framework
+    """
+
+    def __init__(self, db: MemoryStorage, path_id: str, moving_window: limits.strategies.MovingWindowRateLimiter,
+                 keyfunc: Callable,
+                 error_handler: Optional[Union[Callable, Awaitable]] = None) -> None:
+        self.keyfunc = keyfunc
+        self.error_handler = error_handler
+        self.db = db
+        self.path_id = path_id
+        self.moving_window = moving_window
+        self.items = {}
+
+    def create_or_get_item(self, key: str, ratelimit: str) -> limits.RateLimitItem:
+        if key in self.items:
+            return self.items[key]
+
+        calls, period = ratelimit.split("/")
+        calls = int(calls)
+        period = int(period)
+        assert period > 0
+        assert calls > 0
+
+        if period >= 31_536_000:
+            item = limits.RateLimitItemPerYear(calls, period / 31_536_000)
+        elif period >= 2_628_000:
+            item = limits.RateLimitItemPerMonth(calls, period / 2_628_000)
+        elif period >= 86400:
+            item = limits.RateLimitItemPerDay(calls, period / 86400)
+        elif period >= 3600:
+            item = limits.RateLimitItemPerHour(calls, period / 3600)
+        elif period >= 60:
+            item = limits.RateLimitItemPerMinute(calls, period / 60)
+        else:
+            item = limits.RateLimitItemPerSecond(calls, period)
+
+        self.items[key] = item
+
+        return item
+
+    def get_item_for_key(self, key: str) -> limits.RateLimitItem:
+        if not key in self.items:
+            # TODO Issue a warning about this?
+            return self.items['default']
+
+        return self.items[key]
+
+    def __call__(self, func: Callable) -> Awaitable:
+        @wraps(func)
+        async def wrapper(*args) -> Response:
+            request = args[1]
+
+            print('request', request)
+            key, ratelimit = self.keyfunc(request)
+            db_key = f"{key}:{self.path_id or request.path}"
+
+            item= self.create_or_get_item(db_key, ratelimit)
+
+            if not self.db.check():
+                self.db.reset()
+
+            if asyncio.iscoroutinefunction(func):
+                # Returns a response if the number of calls exceeds the max amount of calls
+                if not self.moving_window.test(item, db_key):
+                    if self.error_handler is not None:
+                        if asyncio.iscoroutinefunction(self.error_handler):
+                            r = await self.error_handler(request, RateLimitExceeded(
+                                **{"detail": str(item)}))
+                            if isinstance(r, Allow):
+                                return await func(*args)
+                            return r
+                        else:
+                            r = self.error_handler(request, RateLimitExceeded(
+                                **{"detail": str(item)}))
+                            if isinstance(r, Allow):
+                                return await func(*args)
+                            return r
+                    data = json.dumps(
+                        {"error": f"Rate limit exceeded: {item}"})
+                    response = Response(
+                        text=data, content_type="application/json", status=429)
+                    response.headers.add(
+                        "error", f"Rate limit exceeded: {item}")
+                    return response
+
+                self.moving_window.hit(item, db_key)
+                # Returns normal response if the user did not go over the rate limit
+                return await func(*args)
+            else:
+                # Returns a response if the number of calls exceeds the max amount of calls
+                if not self.moving_window.test(item, db_key):
+                    if self.error_handler is not None:
+                        if asyncio.iscoroutinefunction(self.error_handler):
+                            r = await self.error_handler(request, RateLimitExceeded(
+                                **{"detail": str(item)}))
+                            if isinstance(r, Allow):
+                                return func(*args)
+                            return r
+                        else:
+                            r = self.error_handler(request, RateLimitExceeded(
+                                **{"detail": str(item)}))
+                            if isinstance(r, Allow):
+                                return func(*args)
+                            return r
+                    data = json.dumps(
+                        {"error": f"Rate limit exceeded: {item}"})
+                    response = Response(
+                        text=data, content_type="application/json", status=429)
+                    response.headers.add(
+                        "error", f"Rate limit exceeded: {item}")
+                    return response
+
+                self.moving_window.hit(item, db_key)
+                # Returns normal response if the user did not go over the rate limit
+                return func(*args)
+
+        return wrapper
+
+
+class Limiter:
+    """
+    ```
+    limiter = Limiter(keyfunc=your_keyfunc)
+
+    @routes.get("/")
+    @limiter.limit("5/1")  # TODO Change this example
+    def foo():
+        return Response(text="Hello World")
+    ```
+    """
+
+    def __init__(self,
+                 error_handler: Optional[Union[Callable, Awaitable]] = None) -> None:
+        self.error_handler = error_handler
+        self.db = MemoryStorage()
+        self.moving_window = limits.strategies.MovingWindowRateLimiter(self.db)
+
+    def limit(self, keyfunc: Callable,
+              error_handler: Optional[Union[Callable, Awaitable]] = None, path_id: str = None) -> Callable:
+        def wrapper(func: Callable) -> Awaitable:
+            _error_handler = self.error_handler or error_handler
+            return RateLimitDecorator(keyfunc=keyfunc,
+                                      error_handler=_error_handler, db=self.db, path_id=path_id,
+                                      moving_window=self.moving_window)(func)
+
+        return wrapper
+
+    async def reset(self):
+        self.db.reset()


### PR DESCRIPTION
### Acceptance Criteria
- All APIs will have a rate limit of 1 request per second per IP
- It should be possible to choose between Redis or Memory as storage for the rate limits with the `--rate-limits-storage` option
- It should possible to configure the Redis url with the `--redis-url` option
- The rate limits will be disabled by default, and will be enabled only if `--rate-limits-storage` option is passed.

### Notes
This is part of https://github.com/HathorNetwork/internal-issues/issues/79