### PR TITLE
fix: log missing event name

### DIFF
--- a/txstratum/toi_client.py
+++ b/txstratum/toi_client.py
@@ -86,7 +86,7 @@ class TOIAsyncClient:
                 return CheckBlacklist(**r)
             body = await response.text()
             self.log.warning(
-                message="TOI Service unexpected response",
+                "TOI Service unexpected response",
                 status=response.status,
                 body=body,
             )


### PR DESCRIPTION
# Acceptance criteria

- Add event name on log to prevent `TypeError` exception 