### PR TITLE
feat: add min_version parameter for all three wallets and block requests from old ones

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -123,11 +123,9 @@ def get_timestamp(tx_bytes: bytes) -> int:
     return tx.timestamp
 
 
-class AppTestCase(AioHTTPTestCase):
-    async def get_application(self):
-        self.manager = TxMiningManager(backend=None, pubsub=MagicMock(), address=None)
-        self.myapp = App(self.manager)
-        return self.myapp.app
+class BaseAppTestCase(AioHTTPTestCase):
+    __test__ = False
+    version_check: bool
 
     @unittest_run_loop
     async def test_health_check(self):
@@ -486,3 +484,134 @@ class AppTestCase(AioHTTPTestCase):
         data = await resp.json()
         self.assertEqual(400, resp.status)
         self.assertEqual({"error": "non-standard-tx"}, data)
+
+    @unittest_run_loop
+    async def test_check_wallet_version(self):
+        tx_hex = update_timestamp(TX_SCRIPT_DATA25).hex()
+
+        header_desktop_lower = {
+            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HathorWallet/0.22.1 Chrome/73.0.3683.121 Electron/5.0.13 Safari/537.36 HathorWallet/0.22.1"
+        }
+        header_desktop_equal = {
+            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HathorWallet/0.23.0 Chrome/73.0.3683.121 Electron/5.0.13 Safari/537.36 HathorWallet/0.23.0"
+        }
+        header_desktop_higher = {
+            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HathorWallet/0.23.1 Chrome/73.0.3683.121 Electron/5.0.13 Safari/537.36 HathorWallet/0.23.1"
+        }
+
+        # Success with desktop version higher than the minimum
+        resp = await self.client.request("POST", "/submit-job", json={"tx": tx_hex}, headers=header_desktop_higher)
+        await resp.json()
+        self.assertEqual(200, resp.status)
+
+        # Success with desktop version equal to the minimum
+        resp = await self.client.request("POST", "/submit-job", json={"tx": tx_hex}, headers=header_desktop_equal)
+        await resp.json()
+        self.assertEqual(200, resp.status)
+
+        # Error with desktop version lower than the minimum if the app is validating desktop version
+        resp = await self.client.request("POST", "/submit-job", json={"tx": tx_hex}, headers=header_desktop_lower)
+        data = await resp.json()
+        if self.version_check:
+            self.assertEqual(400, resp.status)
+            self.assertEqual({"error": "wallet-version-invalid"}, data)
+        else:
+            self.assertEqual(200, resp.status)
+
+        header_mobile_lower = {
+            "User-Agent": "Hathor Wallet Mobile / 0.18.0"
+        }
+        header_mobile_equal = {
+            "User-Agent": "Hathor Wallet Mobile / 1.18.3"
+        }
+        header_mobile_higher = {
+            "User-Agent": "Hathor Wallet Mobile / 20.1.0"
+        }
+        header_mobile_custom = {
+            "User-Agent": "HathorMobile/1"
+        }
+        header_mobile_custom_wrong = {
+            "User-Agent": "HathorMobile/2"
+        }
+
+        # Success with mobile version higher than the minimum
+        resp = await self.client.request("POST", "/submit-job", json={"tx": tx_hex}, headers=header_mobile_higher)
+        await resp.json()
+        self.assertEqual(200, resp.status)
+
+        # Success with mobile version equal to the minimum
+        resp = await self.client.request("POST", "/submit-job", json={"tx": tx_hex}, headers=header_mobile_equal)
+        await resp.json()
+        self.assertEqual(200, resp.status)
+
+        # Error with mobile version lower than the minimum if the app is validating mobile version
+        resp = await self.client.request("POST", "/submit-job", json={"tx": tx_hex}, headers=header_mobile_lower)
+        data = await resp.json()
+        if self.version_check:
+            self.assertEqual(400, resp.status)
+            self.assertEqual({"error": "wallet-version-invalid"}, data)
+        else:
+            self.assertEqual(200, resp.status)
+
+        # Error with mobile version before v0.18.0, if the app is validating mobile version
+        resp = await self.client.request("POST", "/submit-job", json={"tx": tx_hex}, headers=header_mobile_custom)
+        data = await resp.json()
+        if self.version_check:
+            self.assertEqual(400, resp.status)
+            self.assertEqual({"error": "wallet-version-invalid"}, data)
+        else:
+            self.assertEqual(200, resp.status)
+
+        # Success if the custom is different than expected
+        resp = await self.client.request("POST", "/submit-job", json={"tx": tx_hex}, headers=header_mobile_custom_wrong)
+        await resp.json()
+        self.assertEqual(200, resp.status)
+
+
+        header_headless_lower = {
+            "User-Agent": "Hathor Wallet Headless / 0.14.87"
+        }
+        header_headless_equal = {
+            "User-Agent": "Hathor Wallet Headless / 0.14.88"
+        }
+        header_headless_higher = {
+            "User-Agent": "Hathor Wallet Headless / 0.14.89"
+        }
+
+        # Success with headless version higher than the minimum
+        resp = await self.client.request("POST", "/submit-job", json={"tx": tx_hex}, headers=header_headless_higher)
+        await resp.json()
+        self.assertEqual(200, resp.status)
+
+        # Success with headless version equal to the minimum
+        resp = await self.client.request("POST", "/submit-job", json={"tx": tx_hex}, headers=header_headless_equal)
+        await resp.json()
+        self.assertEqual(200, resp.status)
+
+        # Error with headless version lower than the minimum if the app is validating headless version
+        resp = await self.client.request("POST", "/submit-job", json={"tx": tx_hex}, headers=header_headless_lower)
+        data = await resp.json()
+        if self.version_check:
+            self.assertEqual(400, resp.status)
+            self.assertEqual({"error": "wallet-version-invalid"}, data)
+        else:
+            self.assertEqual(200, resp.status)
+
+
+class AppTestCase(BaseAppTestCase):
+    __test__ = True
+
+    async def get_application(self):
+        self.manager = TxMiningManager(backend=None, pubsub=MagicMock(), address=None)
+        self.myapp = App(self.manager)
+        self.version_check = False
+        return self.myapp.app
+
+class AppVersionCheckTestCase(BaseAppTestCase):
+    __test__ = True
+
+    async def get_application(self):
+        self.manager = TxMiningManager(backend=None, pubsub=MagicMock(), address=None)
+        self.myapp = App(self.manager, min_wallet_desktop_version="0.23.0", min_wallet_mobile_version="1.18.3", min_wallet_headless_version="0.14.88")
+        self.version_check = True
+        return self.myapp.app

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -615,6 +615,22 @@ class BaseAppTestCase(AioHTTPTestCase):
         else:
             self.assertEqual(200, resp.status)
 
+        header_headless_wrong1 = {"User-Agent": "Hathor Wallet Headless / 0.xx.88"}
+        header_headless_wrong2 = {"User-Agent": "Hathor Wallet Headless / 0.14.88beta"}
+
+        # Success in both cases because the regex shouldn't identify this as headless versions
+        resp = await self.client.request(
+            "POST", "/submit-job", json={"tx": tx_hex}, headers=header_headless_wrong1
+        )
+        await resp.json()
+        self.assertEqual(200, resp.status)
+
+        resp = await self.client.request(
+            "POST", "/submit-job", json={"tx": tx_hex}, headers=header_headless_wrong2
+        )
+        await resp.json()
+        self.assertEqual(200, resp.status)
+
 
 class AppTestCase(BaseAppTestCase):
     __test__ = True

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -530,7 +530,13 @@ class BaseAppTestCase(AioHTTPTestCase):
         data = await resp.json()
         if self.version_check:
             self.assertEqual(400, resp.status)
-            self.assertEqual({"error": VERSION_CHECK_ERROR_MESSAGE}, data)
+            self.assertEqual(
+                {
+                    "error": VERSION_CHECK_ERROR_MESSAGE,
+                    "data": {"min_version": "0.23.0", "version": "0.22.1"},
+                },
+                data,
+            )
         else:
             self.assertEqual(200, resp.status)
 
@@ -561,7 +567,13 @@ class BaseAppTestCase(AioHTTPTestCase):
         data = await resp.json()
         if self.version_check:
             self.assertEqual(400, resp.status)
-            self.assertEqual({"error": VERSION_CHECK_ERROR_MESSAGE}, data)
+            self.assertEqual(
+                {
+                    "error": VERSION_CHECK_ERROR_MESSAGE,
+                    "data": {"min_version": "1.18.3", "version": "0.18.0"},
+                },
+                data,
+            )
         else:
             self.assertEqual(200, resp.status)
 
@@ -572,7 +584,13 @@ class BaseAppTestCase(AioHTTPTestCase):
         data = await resp.json()
         if self.version_check:
             self.assertEqual(400, resp.status)
-            self.assertEqual({"error": VERSION_CHECK_ERROR_MESSAGE}, data)
+            self.assertEqual(
+                {
+                    "error": VERSION_CHECK_ERROR_MESSAGE,
+                    "data": {"min_version": "1.18.3"},
+                },
+                data,
+            )
         else:
             self.assertEqual(200, resp.status)
 
@@ -611,7 +629,13 @@ class BaseAppTestCase(AioHTTPTestCase):
         data = await resp.json()
         if self.version_check:
             self.assertEqual(400, resp.status)
-            self.assertEqual({"error": VERSION_CHECK_ERROR_MESSAGE}, data)
+            self.assertEqual(
+                {
+                    "error": VERSION_CHECK_ERROR_MESSAGE,
+                    "data": {"min_version": "0.14.88", "version": "0.14.87"},
+                },
+                data,
+            )
         else:
             self.assertEqual(200, resp.status)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -490,27 +490,42 @@ class BaseAppTestCase(AioHTTPTestCase):
         tx_hex = update_timestamp(TX_SCRIPT_DATA25).hex()
 
         header_desktop_lower = {
-            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HathorWallet/0.22.1 Chrome/73.0.3683.121 Electron/5.0.13 Safari/537.36 HathorWallet/0.22.1"
+            "User-Agent": (
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko)"
+                "HathorWallet/0.22.1 Chrome/73.0.3683.121 Electron/5.0.13 Safari/537.36 HathorWallet/0.22.1"
+            )
         }
         header_desktop_equal = {
-            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HathorWallet/0.23.0 Chrome/73.0.3683.121 Electron/5.0.13 Safari/537.36 HathorWallet/0.23.0"
+            "User-Agent": (
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko)"
+                "HathorWallet/0.23.0 Chrome/73.0.3683.121 Electron/5.0.13 Safari/537.36 HathorWallet/0.23.0"
+            )
         }
         header_desktop_higher = {
-            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HathorWallet/0.23.1 Chrome/73.0.3683.121 Electron/5.0.13 Safari/537.36 HathorWallet/0.23.1"
+            "User-Agent": (
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko)"
+                "HathorWallet/0.23.1 Chrome/73.0.3683.121 Electron/5.0.13 Safari/537.36 HathorWallet/0.23.1"
+            )
         }
 
         # Success with desktop version higher than the minimum
-        resp = await self.client.request("POST", "/submit-job", json={"tx": tx_hex}, headers=header_desktop_higher)
+        resp = await self.client.request(
+            "POST", "/submit-job", json={"tx": tx_hex}, headers=header_desktop_higher
+        )
         await resp.json()
         self.assertEqual(200, resp.status)
 
         # Success with desktop version equal to the minimum
-        resp = await self.client.request("POST", "/submit-job", json={"tx": tx_hex}, headers=header_desktop_equal)
+        resp = await self.client.request(
+            "POST", "/submit-job", json={"tx": tx_hex}, headers=header_desktop_equal
+        )
         await resp.json()
         self.assertEqual(200, resp.status)
 
         # Error with desktop version lower than the minimum if the app is validating desktop version
-        resp = await self.client.request("POST", "/submit-job", json={"tx": tx_hex}, headers=header_desktop_lower)
+        resp = await self.client.request(
+            "POST", "/submit-job", json={"tx": tx_hex}, headers=header_desktop_lower
+        )
         data = await resp.json()
         if self.version_check:
             self.assertEqual(400, resp.status)
@@ -518,34 +533,30 @@ class BaseAppTestCase(AioHTTPTestCase):
         else:
             self.assertEqual(200, resp.status)
 
-        header_mobile_lower = {
-            "User-Agent": "Hathor Wallet Mobile / 0.18.0"
-        }
-        header_mobile_equal = {
-            "User-Agent": "Hathor Wallet Mobile / 1.18.3"
-        }
-        header_mobile_higher = {
-            "User-Agent": "Hathor Wallet Mobile / 20.1.0"
-        }
-        header_mobile_custom = {
-            "User-Agent": "HathorMobile/1"
-        }
-        header_mobile_custom_wrong = {
-            "User-Agent": "HathorMobile/2"
-        }
+        header_mobile_lower = {"User-Agent": "Hathor Wallet Mobile / 0.18.0"}
+        header_mobile_equal = {"User-Agent": "Hathor Wallet Mobile / 1.18.3"}
+        header_mobile_higher = {"User-Agent": "Hathor Wallet Mobile / 20.1.0"}
+        header_mobile_custom = {"User-Agent": "HathorMobile/1"}
+        header_mobile_custom_wrong = {"User-Agent": "HathorMobile/2"}
 
         # Success with mobile version higher than the minimum
-        resp = await self.client.request("POST", "/submit-job", json={"tx": tx_hex}, headers=header_mobile_higher)
+        resp = await self.client.request(
+            "POST", "/submit-job", json={"tx": tx_hex}, headers=header_mobile_higher
+        )
         await resp.json()
         self.assertEqual(200, resp.status)
 
         # Success with mobile version equal to the minimum
-        resp = await self.client.request("POST", "/submit-job", json={"tx": tx_hex}, headers=header_mobile_equal)
+        resp = await self.client.request(
+            "POST", "/submit-job", json={"tx": tx_hex}, headers=header_mobile_equal
+        )
         await resp.json()
         self.assertEqual(200, resp.status)
 
         # Error with mobile version lower than the minimum if the app is validating mobile version
-        resp = await self.client.request("POST", "/submit-job", json={"tx": tx_hex}, headers=header_mobile_lower)
+        resp = await self.client.request(
+            "POST", "/submit-job", json={"tx": tx_hex}, headers=header_mobile_lower
+        )
         data = await resp.json()
         if self.version_check:
             self.assertEqual(400, resp.status)
@@ -554,7 +565,9 @@ class BaseAppTestCase(AioHTTPTestCase):
             self.assertEqual(200, resp.status)
 
         # Error with mobile version before v0.18.0, if the app is validating mobile version
-        resp = await self.client.request("POST", "/submit-job", json={"tx": tx_hex}, headers=header_mobile_custom)
+        resp = await self.client.request(
+            "POST", "/submit-job", json={"tx": tx_hex}, headers=header_mobile_custom
+        )
         data = await resp.json()
         if self.version_check:
             self.assertEqual(400, resp.status)
@@ -563,33 +576,37 @@ class BaseAppTestCase(AioHTTPTestCase):
             self.assertEqual(200, resp.status)
 
         # Success if the custom is different than expected
-        resp = await self.client.request("POST", "/submit-job", json={"tx": tx_hex}, headers=header_mobile_custom_wrong)
+        resp = await self.client.request(
+            "POST",
+            "/submit-job",
+            json={"tx": tx_hex},
+            headers=header_mobile_custom_wrong,
+        )
         await resp.json()
         self.assertEqual(200, resp.status)
 
-
-        header_headless_lower = {
-            "User-Agent": "Hathor Wallet Headless / 0.14.87"
-        }
-        header_headless_equal = {
-            "User-Agent": "Hathor Wallet Headless / 0.14.88"
-        }
-        header_headless_higher = {
-            "User-Agent": "Hathor Wallet Headless / 0.14.89"
-        }
+        header_headless_lower = {"User-Agent": "Hathor Wallet Headless / 0.14.87"}
+        header_headless_equal = {"User-Agent": "Hathor Wallet Headless / 0.14.88"}
+        header_headless_higher = {"User-Agent": "Hathor Wallet Headless / 0.14.89"}
 
         # Success with headless version higher than the minimum
-        resp = await self.client.request("POST", "/submit-job", json={"tx": tx_hex}, headers=header_headless_higher)
+        resp = await self.client.request(
+            "POST", "/submit-job", json={"tx": tx_hex}, headers=header_headless_higher
+        )
         await resp.json()
         self.assertEqual(200, resp.status)
 
         # Success with headless version equal to the minimum
-        resp = await self.client.request("POST", "/submit-job", json={"tx": tx_hex}, headers=header_headless_equal)
+        resp = await self.client.request(
+            "POST", "/submit-job", json={"tx": tx_hex}, headers=header_headless_equal
+        )
         await resp.json()
         self.assertEqual(200, resp.status)
 
         # Error with headless version lower than the minimum if the app is validating headless version
-        resp = await self.client.request("POST", "/submit-job", json={"tx": tx_hex}, headers=header_headless_lower)
+        resp = await self.client.request(
+            "POST", "/submit-job", json={"tx": tx_hex}, headers=header_headless_lower
+        )
         data = await resp.json()
         if self.version_check:
             self.assertEqual(400, resp.status)
@@ -607,11 +624,17 @@ class AppTestCase(BaseAppTestCase):
         self.version_check = False
         return self.myapp.app
 
+
 class AppVersionCheckTestCase(BaseAppTestCase):
     __test__ = True
 
     async def get_application(self):
         self.manager = TxMiningManager(backend=None, pubsub=MagicMock(), address=None)
-        self.myapp = App(self.manager, min_wallet_desktop_version="0.23.0", min_wallet_mobile_version="1.18.3", min_wallet_headless_version="0.14.88")
+        self.myapp = App(
+            self.manager,
+            min_wallet_desktop_version="0.23.0",
+            min_wallet_mobile_version="1.18.3",
+            min_wallet_headless_version="0.14.88",
+        )
         self.version_check = True
         return self.myapp.app

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -16,6 +16,7 @@ from txstratum.api import (
     App,
 )
 from txstratum.manager import TxMiningManager
+from txstratum.middleware import VERSION_CHECK_ERROR_MESSAGE
 from txstratum.utils import tx_or_block_from_bytes
 
 from .tx_examples import INVALID_TX_DATA
@@ -529,7 +530,7 @@ class BaseAppTestCase(AioHTTPTestCase):
         data = await resp.json()
         if self.version_check:
             self.assertEqual(400, resp.status)
-            self.assertEqual({"error": "wallet-version-invalid"}, data)
+            self.assertEqual({"error": VERSION_CHECK_ERROR_MESSAGE}, data)
         else:
             self.assertEqual(200, resp.status)
 
@@ -560,7 +561,7 @@ class BaseAppTestCase(AioHTTPTestCase):
         data = await resp.json()
         if self.version_check:
             self.assertEqual(400, resp.status)
-            self.assertEqual({"error": "wallet-version-invalid"}, data)
+            self.assertEqual({"error": VERSION_CHECK_ERROR_MESSAGE}, data)
         else:
             self.assertEqual(200, resp.status)
 
@@ -571,7 +572,7 @@ class BaseAppTestCase(AioHTTPTestCase):
         data = await resp.json()
         if self.version_check:
             self.assertEqual(400, resp.status)
-            self.assertEqual({"error": "wallet-version-invalid"}, data)
+            self.assertEqual({"error": VERSION_CHECK_ERROR_MESSAGE}, data)
         else:
             self.assertEqual(200, resp.status)
 
@@ -610,7 +611,7 @@ class BaseAppTestCase(AioHTTPTestCase):
         data = await resp.json()
         if self.version_check:
             self.assertEqual(400, resp.status)
-            self.assertEqual({"error": "wallet-version-invalid"}, data)
+            self.assertEqual({"error": VERSION_CHECK_ERROR_MESSAGE}, data)
         else:
             self.assertEqual(200, resp.status)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,18 +12,18 @@ from txstratum.utils import is_version_gte
 
 class UtilsTestCase(unittest.TestCase):
     def test_versions_check(self):
-        self.assertTrue(is_version_gte('1.2.3', '1.2.3'))
-        self.assertFalse(is_version_gte('1.2.2', '1.2.3'))
-        self.assertTrue(is_version_gte('1.2.4', '1.2.3'))
+        self.assertTrue(is_version_gte("1.2.3", "1.2.3"))
+        self.assertFalse(is_version_gte("1.2.2", "1.2.3"))
+        self.assertTrue(is_version_gte("1.2.4", "1.2.3"))
 
-        self.assertTrue(is_version_gte('2.2.4', '1.2.3'))
-        self.assertTrue(is_version_gte('1.3.4', '1.2.3'))
-        self.assertFalse(is_version_gte('0.3.4', '1.2.3'))
+        self.assertTrue(is_version_gte("2.2.4", "1.2.3"))
+        self.assertTrue(is_version_gte("1.3.4", "1.2.3"))
+        self.assertFalse(is_version_gte("0.3.4", "1.2.3"))
 
-        self.assertFalse(is_version_gte('0.3.4', '1.2.3'))
-
-        with self.assertRaises(InvalidVersionFormat):
-            is_version_gte('0.3.4.5', '0.3.4')
+        self.assertFalse(is_version_gte("0.3.4", "1.2.3"))
 
         with self.assertRaises(InvalidVersionFormat):
-            is_version_gte('0.3.4', '0.3.4.5')
+            is_version_gte("0.3.4.5", "0.3.4")
+
+        with self.assertRaises(InvalidVersionFormat):
+            is_version_gte("0.3.4", "0.3.4.5")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,29 @@
+"""
+Copyright (c) Hathor Labs and its affiliates.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+"""
+import unittest
+
+from txstratum.exceptions import InvalidVersionFormat
+from txstratum.utils import is_version_gte
+
+
+class UtilsTestCase(unittest.TestCase):
+    def test_versions_check(self):
+        self.assertTrue(is_version_gte('1.2.3', '1.2.3'))
+        self.assertFalse(is_version_gte('1.2.2', '1.2.3'))
+        self.assertTrue(is_version_gte('1.2.4', '1.2.3'))
+
+        self.assertTrue(is_version_gte('2.2.4', '1.2.3'))
+        self.assertTrue(is_version_gte('1.3.4', '1.2.3'))
+        self.assertFalse(is_version_gte('0.3.4', '1.2.3'))
+
+        self.assertFalse(is_version_gte('0.3.4', '1.2.3'))
+
+        with self.assertRaises(InvalidVersionFormat):
+            is_version_gte('0.3.4.5', '0.3.4')
+
+        with self.assertRaises(InvalidVersionFormat):
+            is_version_gte('0.3.4', '0.3.4.5')

--- a/txstratum/api.py
+++ b/txstratum/api.py
@@ -66,7 +66,15 @@ class App:
         self.tx_timeout: float = tx_timeout or TX_TIMEOUT
         self.only_standard_script: bool = only_standard_script
         self.tx_filters = tx_filters or []
-        self.app = web.Application(middlewares=[create_middleware_version_check(min_wallet_desktop_version, min_wallet_mobile_version, min_wallet_headless_version)])
+        self.app = web.Application(
+            middlewares=[
+                create_middleware_version_check(
+                    min_wallet_desktop_version,
+                    min_wallet_mobile_version,
+                    min_wallet_headless_version,
+                )
+            ]
+        )
         self.app.router.add_get("/health-check", self.health_check)
         self.app.router.add_get("/mining-status", self.mining_status)
         self.app.router.add_get("/job-status", self.job_status)

--- a/txstratum/api.py
+++ b/txstratum/api.py
@@ -14,6 +14,7 @@ from structlog import get_logger
 import txstratum.time
 from txstratum.exceptions import JobAlreadyExists, NewJobRefused
 from txstratum.jobs import JobStatus, TxJob
+from txstratum.middleware import create_middleware_version_check
 from txstratum.utils import tx_or_block_from_bytes
 
 if TYPE_CHECKING:
@@ -50,7 +51,10 @@ class App:
         fix_invalid_timestamp: bool = False,
         max_output_script_size: Optional[int] = None,
         only_standard_script: bool = True,
-        tx_filters: Optional[List["TXFilter"]] = None
+        tx_filters: Optional[List["TXFilter"]] = None,
+        min_wallet_desktop_version: Optional[str] = None,
+        min_wallet_mobile_version: Optional[str] = None,
+        min_wallet_headless_version: Optional[str] = None,
     ):
         """Init App."""
         super().__init__()
@@ -62,7 +66,7 @@ class App:
         self.tx_timeout: float = tx_timeout or TX_TIMEOUT
         self.only_standard_script: bool = only_standard_script
         self.tx_filters = tx_filters or []
-        self.app = web.Application()
+        self.app = web.Application(middlewares=[create_middleware_version_check(min_wallet_desktop_version, min_wallet_mobile_version, min_wallet_headless_version)])
         self.app.router.add_get("/health-check", self.health_check)
         self.app.router.add_get("/mining-status", self.mining_status)
         self.app.router.add_get("/job-status", self.job_status)

--- a/txstratum/cli.py
+++ b/txstratum/cli.py
@@ -109,6 +109,27 @@ def create_parser() -> ArgumentParser:
         "backend", help="Endpoint of the Hathor API (without version)", type=str
     )
 
+    parser.add_argument(
+        "--min-wallet-desktop-version",
+        help="Minimum version for the wallet desktop to use this tx mining",
+        type=str,
+        default=None,
+    )
+
+    parser.add_argument(
+        "--min-wallet-mobile-version",
+        help="Minimum version for the wallet mobile to use this tx mining",
+        type=str,
+        default=None,
+    )
+
+    parser.add_argument(
+        "--min-wallet-headless-version",
+        help="Minimum version for the wallet headless to use this tx mining",
+        type=str,
+        default=None,
+    )
+
     logs = parser.add_mutually_exclusive_group()
     logs.add_argument(
         "--log-config",
@@ -238,6 +259,9 @@ class RunService:
             fix_invalid_timestamp=self.args.fix_invalid_timestamp,
             only_standard_script=not self.args.allow_non_standard_script,
             tx_filters=self.tx_filters,
+            min_wallet_desktop_version=self.args.min_wallet_desktop_version,
+            min_wallet_mobile_version=self.args.min_wallet_mobile_version,
+            min_wallet_headless_version=self.args.min_wallet_headless_version,
         )
 
         logger.info(
@@ -248,6 +272,9 @@ class RunService:
             fix_invalid_timestamp=api_app.fix_invalid_timestamp,
             only_standard_script=api_app.only_standard_script,
             tx_filters=self.tx_filters,
+            min_wallet_desktop_version=self.args.min_wallet_desktop_version,
+            min_wallet_mobile_version=self.args.min_wallet_mobile_version,
+            min_wallet_headless_version=self.args.min_wallet_headless_version,
         )
 
         web_runner = web.AppRunner(api_app.app, logger=logger)

--- a/txstratum/exceptions.py
+++ b/txstratum/exceptions.py
@@ -8,3 +8,9 @@ class JobAlreadyExists(Exception):
     """Exception raised when a job already exists."""
 
     pass
+
+
+class InvalidVersionFormat(Exception):
+    """Exception raised when comparing versions that are in the wrong format."""
+
+    pass

--- a/txstratum/middleware.py
+++ b/txstratum/middleware.py
@@ -4,23 +4,27 @@
 # LICENSE file in the root directory of this source tree.
 
 import re
-from pkg_resources import packaging
 from typing import Callable, Optional
 
 from aiohttp import web
+from pkg_resources import packaging
 
 handler_callable = Callable[[web.Request], web.Response]
 
 
-def create_middleware_version_check(min_wallet_desktop_version: Optional[str], min_wallet_mobile_version: Optional[str], min_wallet_headless_version: Optional[str]) -> Callable[[web.Request, handler_callable], web.Response]:
-    """ Middleware factory
-    """
+def create_middleware_version_check(
+    min_wallet_desktop_version: Optional[str],
+    min_wallet_mobile_version: Optional[str],
+    min_wallet_headless_version: Optional[str],
+) -> Callable[[web.Request, handler_callable], web.Response]:
+    """Middleware factory."""
 
     @web.middleware
-    async def version_check(request: web.Request, handler: handler_callable) -> web.Response:
-        """ Check wallet versions from user agent
-        """
-        user_agent = request.headers.get('User-Agent')
+    async def version_check(
+        request: web.Request, handler: handler_callable
+    ) -> web.Response:
+        """Check wallet versions from user agent."""
+        user_agent = request.headers.get("User-Agent")
 
         if min_wallet_desktop_version:
             # Search user agent for wallet desktop string and get version
@@ -28,37 +32,53 @@ def create_middleware_version_check(min_wallet_desktop_version: Optional[str], m
             # Example of a wallet desktop user agent
             # Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HathorWallet/0.22.1
             # Chrome/73.0.3683.121 Electron/5.0.13 Safari/537.36 HathorWallet/0.22.1
-            wallet_desktop_regex = "HathorWallet/(\d+\.\d+.\d+)"
-            if is_version_invalid(wallet_desktop_regex, user_agent, min_wallet_desktop_version):
-                return web.json_response({"error": "wallet-version-invalid"}, status=400)
+            wallet_desktop_regex = r"HathorWallet/(\d+\.\d+.\d+)"
+            if is_version_invalid(
+                wallet_desktop_regex, user_agent, min_wallet_desktop_version
+            ):
+                return web.json_response(
+                    {"error": "wallet-version-invalid"}, status=400
+                )
 
         if min_wallet_mobile_version:
             # Search user agent for wallet mobile string and get version
             # Then check if version is the minimum allowed
             # Example of a wallet mobile user agent
             # Hathor Wallet Mobile / 0.18.0
-            wallet_mobile_regex = "Hathor Wallet Mobile / (\d+\.\d+\.\d+)"
-            if is_version_invalid(wallet_mobile_regex, user_agent, min_wallet_mobile_version):
-                return web.json_response({"error": "wallet-version-invalid"}, status=400)
+            wallet_mobile_regex = r"Hathor Wallet Mobile / (\d+\.\d+\.\d+)"
+            if is_version_invalid(
+                wallet_mobile_regex, user_agent, min_wallet_mobile_version
+            ):
+                return web.json_response(
+                    {"error": "wallet-version-invalid"}, status=400
+                )
 
             # Before version 0.18.0 in the wallet mobile, the user agent was receiving a fixed "version"
             # the user agent was "HathorMobile/1", so if the min version is at least 0.18.0, then
             # we must have a custom check here for it
-            if packaging.version.parse(min_wallet_mobile_version) >= packaging.version.parse("0.18.0"):
+            if packaging.version.parse(
+                min_wallet_mobile_version
+            ) >= packaging.version.parse("0.18.0"):
                 custom_regex = "HathorMobile/1"
                 search = re.search(custom_regex, user_agent)
                 if search:
                     # If the regex found it, then we should block
-                    return web.json_response({"error": "wallet-version-invalid"}, status=400)
+                    return web.json_response(
+                        {"error": "wallet-version-invalid"}, status=400
+                    )
 
         if min_wallet_headless_version:
             # Seach user agent for wallet headless string and get version
             # Then check if version is the minimum allowed
             # Example of a wallet headless user agent
             # Hathor Wallet Headless / 0.14.0
-            wallet_headless_regex = "Hathor Wallet Headless / (\d+\.\d+\.\d+)"
-            if is_version_invalid(wallet_headless_regex, user_agent, min_wallet_headless_version):
-                return web.json_response({"error": "wallet-version-invalid"}, status=400)
+            wallet_headless_regex = r"Hathor Wallet Headless / (\d+\.\d+\.\d+)"
+            if is_version_invalid(
+                wallet_headless_regex, user_agent, min_wallet_headless_version
+            ):
+                return web.json_response(
+                    {"error": "wallet-version-invalid"}, status=400
+                )
 
         return await handler(request)
 
@@ -66,8 +86,9 @@ def create_middleware_version_check(min_wallet_desktop_version: Optional[str], m
 
 
 def is_version_invalid(regex: str, user_agent: str, min_version: str) -> bool:
-    """ Checks if version in user agent is invalid comparing with min version
-        Regex is used to get the version from user agent
+    """Check if version in user agent is invalid comparing with min version.
+
+    Regex is used to get the version from user agent
     """
     search = re.search(regex, user_agent)
     if search and search.groups():

--- a/txstratum/middleware.py
+++ b/txstratum/middleware.py
@@ -1,0 +1,77 @@
+# Copyright (c) Hathor Labs and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import re
+from pkg_resources import packaging
+from typing import Callable, Optional
+
+from aiohttp import web
+
+handler_callable = Callable[[web.Request], web.Response]
+
+
+def create_middleware_version_check(min_wallet_desktop_version: Optional[str], min_wallet_mobile_version: Optional[str], min_wallet_headless_version: Optional[str]) -> Callable[[web.Request, handler_callable], web.Response]:
+    """ Middleware factory
+    """
+
+    @web.middleware
+    async def version_check(request: web.Request, handler: handler_callable) -> web.Response:
+        """ Check wallet versions from user agent
+        """
+        user_agent = request.headers.get('User-Agent')
+
+        if min_wallet_desktop_version:
+            # Search user agent for wallet desktop string and get version
+            # Then check if version is the minimum allowed
+            # Example of a wallet desktop user agent
+            # Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HathorWallet/0.22.1
+            # Chrome/73.0.3683.121 Electron/5.0.13 Safari/537.36 HathorWallet/0.22.1
+            wallet_desktop_regex = "HathorWallet/(\d+\.\d+.\d+)"
+            if is_version_invalid(wallet_desktop_regex, user_agent, min_wallet_desktop_version):
+                return web.json_response({"error": "wallet-version-invalid"}, status=400)
+
+        if min_wallet_mobile_version:
+            # Search user agent for wallet mobile string and get version
+            # Then check if version is the minimum allowed
+            # Example of a wallet mobile user agent
+            # Hathor Wallet Mobile / 0.18.0
+            wallet_mobile_regex = "Hathor Wallet Mobile / (\d+\.\d+\.\d+)"
+            if is_version_invalid(wallet_mobile_regex, user_agent, min_wallet_mobile_version):
+                return web.json_response({"error": "wallet-version-invalid"}, status=400)
+
+            # Before version 0.18.0 in the wallet mobile, the user agent was receiving a fixed "version"
+            # the user agent was "HathorMobile/1", so if the min version is at least 0.18.0, then
+            # we must have a custom check here for it
+            if packaging.version.parse(min_wallet_mobile_version) >= packaging.version.parse("0.18.0"):
+                custom_regex = "HathorMobile/1"
+                search = re.search(custom_regex, user_agent)
+                if search:
+                    # If the regex found it, then we should block
+                    return web.json_response({"error": "wallet-version-invalid"}, status=400)
+
+        if min_wallet_headless_version:
+            # Seach user agent for wallet headless string and get version
+            # Then check if version is the minimum allowed
+            # Example of a wallet headless user agent
+            # Hathor Wallet Headless / 0.14.0
+            wallet_headless_regex = "Hathor Wallet Headless / (\d+\.\d+\.\d+)"
+            if is_version_invalid(wallet_headless_regex, user_agent, min_wallet_headless_version):
+                return web.json_response({"error": "wallet-version-invalid"}, status=400)
+
+        return await handler(request)
+
+    return version_check
+
+
+def is_version_invalid(regex: str, user_agent: str, min_version: str) -> bool:
+    """ Checks if version in user agent is invalid comparing with min version
+        Regex is used to get the version from user agent
+    """
+    search = re.search(regex, user_agent)
+    if search and search.groups():
+        version = search.groups()[0]
+        return packaging.version.parse(version) < packaging.version.parse(min_version)
+
+    return False

--- a/txstratum/middleware.py
+++ b/txstratum/middleware.py
@@ -11,7 +11,11 @@ from aiohttp.typedefs import Handler
 
 from txstratum.utils import is_version_gte
 
+# Middleware factory return type
 Middleware = Callable[[web.Request, Handler], Awaitable[web.StreamResponse]]
+
+# Error message
+VERSION_CHECK_ERROR_MESSAGE = "wallet-version-too-old"
 
 
 def create_middleware_version_check(
@@ -43,7 +47,7 @@ def create_middleware_version_check(
                 wallet_desktop_regex, user_agent, min_wallet_desktop_version
             ):
                 return web.json_response(
-                    {"error": "wallet-version-invalid"}, status=400
+                    {"error": VERSION_CHECK_ERROR_MESSAGE}, status=400
                 )
 
         if min_wallet_mobile_version:
@@ -56,7 +60,7 @@ def create_middleware_version_check(
                 wallet_mobile_regex, user_agent, min_wallet_mobile_version
             ):
                 return web.json_response(
-                    {"error": "wallet-version-invalid"}, status=400
+                    {"error": VERSION_CHECK_ERROR_MESSAGE}, status=400
                 )
 
             # Before version 0.18.0 in the wallet mobile, the user agent was receiving a fixed "version"
@@ -68,7 +72,7 @@ def create_middleware_version_check(
                 if search:
                     # If the regex found it, then we should block
                     return web.json_response(
-                        {"error": "wallet-version-invalid"}, status=400
+                        {"error": VERSION_CHECK_ERROR_MESSAGE}, status=400
                     )
 
         if min_wallet_headless_version:
@@ -81,7 +85,7 @@ def create_middleware_version_check(
                 wallet_headless_regex, user_agent, min_wallet_headless_version
             ):
                 return web.json_response(
-                    {"error": "wallet-version-invalid"}, status=400
+                    {"error": VERSION_CHECK_ERROR_MESSAGE}, status=400
                 )
 
         response = await handler(request)

--- a/txstratum/utils.py
+++ b/txstratum/utils.py
@@ -414,8 +414,12 @@ def is_version_gte(version: str, base_version: str) -> bool:
     # First we transform the versions from strings in the format X.Y.Z
     # into tuples of integers
 
-    version_int_tuple: Tuple[int] = tuple(map(int, version.split(".")))
-    base_version_int_tuple: Tuple[int] = tuple(map(int, base_version.split(".")))
+    try:
+        version_int_tuple = tuple(map(int, version.split(".")))
+        base_version_int_tuple = tuple(map(int, base_version.split(".")))
+    except ValueError:
+        # version strings are not in the expected format
+        return False
 
     assert len(version_int_tuple) == len(base_version_int_tuple)
 

--- a/txstratum/utils.py
+++ b/txstratum/utils.py
@@ -411,16 +411,12 @@ def is_version_gte(version: str, base_version: str) -> bool:
 
     Validates if version is greater than or equal to base_version
     """
-    version_split = version.split(".")
-    base_version_split = base_version.split(".")
+    # First we transform the versions from strings in the format X.Y.Z
+    # into tuples of integers
 
-    assert len(version_split) == len(base_version_split)
+    version_int_tuple: Tuple[int] = tuple(map(int, version.split(".")))
+    base_version_int_tuple: Tuple[int] = tuple(map(int, base_version.split(".")))
 
-    for i in range(len(version_split)):
-        if base_version_split[i] > version_split[i]:
-            return False
-        elif base_version_split[i] < version_split[i]:
-            return True
+    assert len(version_int_tuple) == len(base_version_int_tuple)
 
-    # Both versions are equal
-    return True
+    return version_int_tuple >= base_version_int_tuple

--- a/txstratum/utils.py
+++ b/txstratum/utils.py
@@ -25,6 +25,7 @@ from typing import (
 from structlog import get_logger
 
 from txstratum.constants import DEFAULT_EXPECTED_MINING_TIME
+from txstratum.exceptions import InvalidVersionFormat
 
 if TYPE_CHECKING:
     from asyncio.events import AbstractEventLoop
@@ -421,6 +422,7 @@ def is_version_gte(version: str, base_version: str) -> bool:
         # version strings are not in the expected format
         return False
 
-    assert len(version_int_tuple) == len(base_version_int_tuple)
+    if len(version_int_tuple) != len(base_version_int_tuple):
+        raise InvalidVersionFormat(f"Expected version format is X.Y.Z, and received version {version} and base version {base_version}")
 
     return version_int_tuple >= base_version_int_tuple

--- a/txstratum/utils.py
+++ b/txstratum/utils.py
@@ -423,6 +423,8 @@ def is_version_gte(version: str, base_version: str) -> bool:
         return False
 
     if len(version_int_tuple) != len(base_version_int_tuple):
-        raise InvalidVersionFormat(f"Expected version format is X.Y.Z, and received version {version} and base version {base_version}")
+        raise InvalidVersionFormat(
+            f"Expected version format is X.Y.Z, and received version {version} and base version {base_version}"
+        )
 
     return version_int_tuple >= base_version_int_tuple

--- a/txstratum/utils.py
+++ b/txstratum/utils.py
@@ -404,3 +404,23 @@ def start_logging(loop: Optional["AbstractEventLoop"] = None) -> None:
         logger.exception(message, **extra, exc_info=exc_info)
 
     loop.set_exception_handler(_exception_handler)
+
+
+def is_version_gte(version: str, base_version: str) -> bool:
+    """Compare two versions in the format X.Y.Z.
+
+    Validates if version is greater than or equal to base_version
+    """
+    version_split = version.split(".")
+    base_version_split = base_version.split(".")
+
+    assert len(version_split) == len(base_version_split)
+
+    for i in range(len(version_split)):
+        if base_version_split[i] > version_split[i]:
+            return False
+        elif base_version_split[i] < version_split[i]:
+            return True
+
+    # Both versions are equal
+    return True


### PR DESCRIPTION
### Acceptance Criteria

- We must be able to block from old wallet versions. This is done getting the wallet version from the user agent and comparing with the minimum allowed version set in the command line argument.
- This should be possible for wallet desktop, mobile and headless.