### PR TITLE
chore: temporarily remove docker build for arm

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -58,6 +58,6 @@ jobs:
       with:
         push: true
         tags: ${{ steps.tags.outputs.tags }}
-        platforms: linux/amd64,linux/arm64
+        platforms: linux/amd64
         cache-from: type=gha
         cache-to: type=gha,mode=max


### PR DESCRIPTION
### Summary

See this https://github.com/HathorNetwork/tx-mining-service/pull/84 for more details about the docker build failing.

### Acceptance Criteria

- We must remove the docker build for arm platform