### PR TITLE
chore: update hathor-lib

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -680,14 +680,14 @@ files = [
 
 [[package]]
 name = "hathorlib"
-version = "0.4.0"
+version = "0.5.1"
 description = "Hathor Network base objects library"
 category = "main"
 optional = false
 python-versions = ">=3.9,<4"
 files = [
-    {file = "hathorlib-0.4.0-py3-none-any.whl", hash = "sha256:4d97eaa21b6cc66e31b662b7959371b676715898b32fc028ca7809e64f938014"},
-    {file = "hathorlib-0.4.0.tar.gz", hash = "sha256:f818ed304088a722152136c50695c2798fef862f3832a9dd9960182fd18617e1"},
+    {file = "hathorlib-0.5.1-py3-none-any.whl", hash = "sha256:0725d7e7b833dc465b4961e7157caaabaa3f0e0e4c98c51e5a40160905218f01"},
+    {file = "hathorlib-0.5.1.tar.gz", hash = "sha256:efb41a27a0e0f8b9a0c5d61cb3f82dbb935b2494429bbb0ba4da673c8dd7255d"},
 ]
 
 [package.dependencies]
@@ -1289,4 +1289,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4.0"
-content-hash = "4bdbccaea859fca007136c807aea18b62d69b600c490dce849b75e59f62e98f6"
+content-hash = "a0b38867164f0d09a281d5fb04b7773df2b5fca7391f0156698ac7c73112d23d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ structlog = "~22.3.0"
 prometheus-client = "^0.9.0"
 idna_ssl = "^1.1.0"
 asynctest = "^0.13.0"
-hathorlib = {version = "^0.4.0", extras = ["client"]}
+hathorlib = {version = "^0.5.1", extras = ["client"]}
 dataclasses = {version = "^0.8", python = ">=3.6,<3.7"}
 
 [tool.poetry.dev-dependencies]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -7,6 +7,7 @@ LICENSE file in the root directory of this source tree.
 from unittest.mock import MagicMock
 
 from aiohttp.test_utils import AioHTTPTestCase, unittest_run_loop
+from hathorlib.base_transaction import tx_or_block_from_bytes
 
 import txstratum.time
 from txstratum.api import (
@@ -21,7 +22,6 @@ from txstratum.middleware import (
     HEADER_SKIP_VERSION_CHECK_VALUE,
     VERSION_CHECK_ERROR_MESSAGE,
 )
-from txstratum.utils import tx_or_block_from_bytes
 
 from .tx_examples import INVALID_TX_DATA
 

--- a/txstratum/api.py
+++ b/txstratum/api.py
@@ -4,10 +4,12 @@
 # LICENSE file in the root directory of this source tree.
 
 import json
+from struct import error as StructError
 from typing import TYPE_CHECKING, List, Optional
 
 from aiohttp import web
 from hathorlib import TokenCreationTransaction, Transaction
+from hathorlib.base_transaction import tx_or_block_from_bytes
 from hathorlib.exceptions import TxValidationError
 from structlog import get_logger
 
@@ -15,7 +17,6 @@ import txstratum.time
 from txstratum.exceptions import JobAlreadyExists, NewJobRefused
 from txstratum.jobs import JobStatus, TxJob
 from txstratum.middleware import create_middleware_version_check
-from txstratum.utils import tx_or_block_from_bytes
 
 if TYPE_CHECKING:
     from txstratum.filters import TXFilter
@@ -116,7 +117,7 @@ class App:
         try:
             tx_bytes = bytes.fromhex(tx_hex)
             tx = tx_or_block_from_bytes(tx_bytes)
-        except (ValueError, TxValidationError):
+        except (ValueError, TxValidationError, StructError):
             self.log.debug("invalid-tx(1)", data=data)
             return web.json_response({"error": "invalid-tx"}, status=400)
 

--- a/txstratum/jobs.py
+++ b/txstratum/jobs.py
@@ -9,10 +9,10 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set
 
 from hathorlib import BaseTransaction, Block
+from hathorlib.base_transaction import tx_or_block_from_bytes
 from hathorlib.scripts import create_output_script
 
 import txstratum.time
-from txstratum.utils import tx_or_block_from_bytes
 
 if TYPE_CHECKING:
     from asyncio import TimerHandle

--- a/txstratum/utils.py
+++ b/txstratum/utils.py
@@ -30,8 +30,6 @@ from txstratum.exceptions import InvalidVersionFormat
 if TYPE_CHECKING:
     from asyncio.events import AbstractEventLoop
 
-    from hathorlib import BaseTransaction
-
 logger = get_logger()
 
 
@@ -354,18 +352,6 @@ def calculate_expected_mining_time(
         # docstring of the constant.
         return DEFAULT_EXPECTED_MINING_TIME
     return 3 * (2 ** (job_weight - 30)) / miners_hashrate_ghs
-
-
-def tx_or_block_from_bytes(data: bytes) -> "BaseTransaction":
-    """Create the correct tx subclass from a sequence of bytes."""
-    from hathorlib import TxVersion
-
-    # version field takes up the first 2 bytes
-    version = int.from_bytes(data[0:2], "big")
-
-    tx_version = TxVersion(version)
-    cls = tx_version.get_cls()
-    return cls.create_from_struct(data)
 
 
 def start_logging(loop: Optional["AbstractEventLoop"] = None) -> None:


### PR DESCRIPTION
### Acceptance Criteria

- Update python-hathorlib to v0.5.1. This version adds support for Feature Activation signal bits.
- Remove `tx_or_block_from_bytes()` function from utils, and use the one from `python-hathorlib` instead.
- Add `StructError` to API error handling, as this was changed in `python-hathorlib`.