### PR TITLE
feat: health check

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -7,7 +7,6 @@ LICENSE file in the root directory of this source tree.
 from unittest.mock import MagicMock
 
 from aiohttp.test_utils import AioHTTPTestCase, unittest_run_loop
-from txstratum.healthcheck import HealthCheck
 
 import txstratum.time
 from txstratum.api import (
@@ -138,8 +137,10 @@ class BaseAppTestCase(AioHTTPTestCase):
         health_check_result = MagicMock()
         health_check_result.get_http_status_code.return_value = 200
         health_check_result.to_json.return_value = {"status": "pass"}
+
         async def side_effect():
             return health_check_result
+
         self.healthcheck.get_health_check.side_effect = side_effect
 
         resp = await self.client.request("GET", "/health")

--- a/tests/test_healthcheck.py
+++ b/tests/test_healthcheck.py
@@ -1,45 +1,53 @@
 from unittest.mock import MagicMock
 
-import asynctest
-from txstratum.healthcheck import FullnodeHealthCheck, HealthCheck, MiningHealthCheck, ComponentType, HealthCheckStatus
+import asynctest  # type: ignore[import]
+
+from txstratum.healthcheck import (
+    ComponentType,
+    FullnodeHealthCheck,
+    HealthCheck,
+    HealthCheckStatus,
+    MiningHealthCheck,
+)
 
 
-class TestFullnodeHealthCheck(asynctest.TestCase):
+class TestFullnodeHealthCheck(asynctest.TestCase):  # type: ignore[misc]
     def setUp(self) -> None:
         self.mock_hathor_client = MagicMock()
-        self.fullnode_health_check = FullnodeHealthCheck(backend=self.mock_hathor_client)
+        self.fullnode_health_check = FullnodeHealthCheck(
+            backend=self.mock_hathor_client
+        )
 
     async def test_get_health_check_with_a_healthy_fullnode(self):
-        """Test the response we should generated for a healthy fullnode
-        """
+        """Test the response we should generated for a healthy fullnode"""
         # Mock the implementation of the hathor_client.version.
         async def side_effect():
-            return {'version': '1.0.0'}
+            return {"version": "1.0.0"}
+
         self.mock_hathor_client.version.side_effect = side_effect
-        self.mock_hathor_client._base_url = 'http://localhost:8080'
+        self.mock_hathor_client._base_url = "http://localhost:8080"
 
         result = await self.fullnode_health_check.get_health_check()
-        self.assertEqual(result.component_name, 'fullnode')
+        self.assertEqual(result.component_name, "fullnode")
         self.assertEqual(result.component_type, ComponentType.FULLNODE)
         self.assertEqual(result.status, HealthCheckStatus.PASS)
-        self.assertEqual(result.output, 'fullnode is responding correctly')
-        self.assertEqual(result.component_id, 'http://localhost:8080')
+        self.assertEqual(result.output, "fullnode is responding correctly")
+        self.assertEqual(result.component_id, "http://localhost:8080")
 
     async def test_get_health_check_with_an_unhealthy_fullnode(self):
-        """Test the response we should generated for an unhealthy fullnode
-        """
-        self.mock_hathor_client.version.side_effect = Exception('error')
-        self.mock_hathor_client._base_url = 'http://localhost:8080'
+        """Test the response we should generated for an unhealthy fullnode"""
+        self.mock_hathor_client.version.side_effect = Exception("error")
+        self.mock_hathor_client._base_url = "http://localhost:8080"
 
         result = await self.fullnode_health_check.get_health_check()
-        self.assertEqual(result.component_name, 'fullnode')
+        self.assertEqual(result.component_name, "fullnode")
         self.assertEqual(result.component_type, ComponentType.FULLNODE)
         self.assertEqual(result.status, HealthCheckStatus.FAIL)
-        self.assertEqual(result.output, 'couldn\'t connect to fullnode')
-        self.assertEqual(result.component_id, 'http://localhost:8080')
+        self.assertEqual(result.output, "couldn't connect to fullnode")
+        self.assertEqual(result.component_id, "http://localhost:8080")
 
 
-class TestMiningHealthCheck(asynctest.TestCase):
+class TestMiningHealthCheck(asynctest.TestCase):  # type: ignore[misc]
     def setUp(self):
         self.manager = MagicMock()
         self.mining_health_check = MiningHealthCheck(manager=self.manager)
@@ -47,31 +55,33 @@ class TestMiningHealthCheck(asynctest.TestCase):
     async def test_get_health_check_no_miners(self):
         self.manager.has_any_miner.return_value = False
         result = await self.mining_health_check.get_health_check()
-        self.assertEqual(result.component_name, 'manager')
+        self.assertEqual(result.component_name, "manager")
         self.assertEqual(result.component_type, ComponentType.INTERNAL)
         self.assertEqual(result.status, HealthCheckStatus.FAIL)
-        self.assertEqual(result.output, 'no miners connected')
+        self.assertEqual(result.output, "no miners connected")
 
     async def test_get_health_check_no_submitted_job_in_period(self):
         self.manager.has_any_miner.return_value = True
         self.manager.has_any_submitted_job_in_period.return_value = False
         result = await self.mining_health_check.get_health_check()
-        self.assertEqual(result.component_name, 'manager')
+        self.assertEqual(result.component_name, "manager")
         self.assertEqual(result.component_type, ComponentType.INTERNAL)
         self.assertEqual(result.status, HealthCheckStatus.FAIL)
-        self.assertEqual(result.output, 'no miners submitted a job in the last 1 hour')
+        self.assertEqual(result.output, "no miners submitted a job in the last 1 hour")
 
     async def test_get_health_check_failed_job(self):
         self.manager.has_any_miner.return_value = True
         self.manager.has_any_submitted_job_in_period.return_value = True
         job = MagicMock()
         job.is_failed.return_value = True
-        self.manager.tx_jobs = {'job_id': job}
+        self.manager.tx_jobs = {"job_id": job}
         result = await self.mining_health_check.get_health_check()
-        self.assertEqual(result.component_name, 'manager')
+        self.assertEqual(result.component_name, "manager")
         self.assertEqual(result.component_type, ComponentType.INTERNAL)
         self.assertEqual(result.status, HealthCheckStatus.FAIL)
-        self.assertEqual(result.output, 'some tx_jobs in the last 5 minutes have failed')
+        self.assertEqual(
+            result.output, "some tx_jobs in the last 5 minutes have failed"
+        )
 
     async def test_get_health_check_slow_job(self):
         self.manager.has_any_miner.return_value = True
@@ -79,12 +89,15 @@ class TestMiningHealthCheck(asynctest.TestCase):
         job = MagicMock()
         job.is_failed.return_value = False
         job.total_time = 11
-        self.manager.tx_jobs = {'job_id': job}
+        self.manager.tx_jobs = {"job_id": job}
         result = await self.mining_health_check.get_health_check()
-        self.assertEqual(result.component_name, 'manager')
+        self.assertEqual(result.component_name, "manager")
         self.assertEqual(result.component_type, ComponentType.INTERNAL)
         self.assertEqual(result.status, HealthCheckStatus.WARN)
-        self.assertEqual(result.output, 'some tx_jobs in the last 5 minutes took more than 10 seconds to be solved')
+        self.assertEqual(
+            result.output,
+            "some tx_jobs in the last 5 minutes took more than 10 seconds to be solved",
+        )
 
     async def test_get_health_check_ok(self):
         self.manager.has_any_miner.return_value = True
@@ -92,79 +105,89 @@ class TestMiningHealthCheck(asynctest.TestCase):
         job = MagicMock()
         job.is_failed.return_value = False
         job.total_time = 9
-        self.manager.tx_jobs = {'job_id': job}
+        self.manager.tx_jobs = {"job_id": job}
         result = await self.mining_health_check.get_health_check()
-        self.assertEqual(result.component_name, 'manager')
+        self.assertEqual(result.component_name, "manager")
         self.assertEqual(result.component_type, ComponentType.INTERNAL)
         self.assertEqual(result.status, HealthCheckStatus.PASS)
-        self.assertEqual(result.output, 'everything is ok')
+        self.assertEqual(result.output, "everything is ok")
 
 
-class TestHealthCheck(asynctest.TestCase):
+class TestHealthCheck(asynctest.TestCase):  # type: ignore[misc]
     def setUp(self):
         self.mock_hathor_client = MagicMock()
         self.mock_manager = MagicMock()
 
-        self.health_check = HealthCheck(manager=self.mock_manager, backend=self.mock_hathor_client)
+        self.health_check = HealthCheck(
+            manager=self.mock_manager, backend=self.mock_hathor_client
+        )
 
     async def test_get_health_check_success(self):
-        """Tests the response we should generate when everything is ok
-        """
+        """Tests the response we should generate when everything is ok"""
         # Mock the implementation of the hathor_client.version.
         async def side_effect():
-            return {'version': '1.0.0'}
+            return {"version": "1.0.0"}
+
         self.mock_hathor_client.version.side_effect = side_effect
-        self.mock_hathor_client._base_url = 'http://localhost:8080'
+        self.mock_hathor_client._base_url = "http://localhost:8080"
 
         self.mock_manager.has_any_miner.return_value = True
         self.mock_manager.has_any_submitted_job_in_period.return_value = True
         job = MagicMock()
         job.is_failed.return_value = False
         job.total_time = 9
-        self.mock_manager.tx_jobs = {'job_id': job}
+        self.mock_manager.tx_jobs = {"job_id": job}
 
         result = await self.health_check.get_health_check()
-        self.assertEqual(result.checks['manager'][0].status, HealthCheckStatus.PASS)
-        self.assertEqual(result.checks['manager'][0].output, 'everything is ok')
-        self.assertEqual(result.checks['fullnode'][0].status, HealthCheckStatus.PASS)
-        self.assertEqual(result.checks['fullnode'][0].output, 'fullnode is responding correctly')
+        self.assertEqual(result.checks["manager"][0].status, HealthCheckStatus.PASS)
+        self.assertEqual(result.checks["manager"][0].output, "everything is ok")
+        self.assertEqual(result.checks["fullnode"][0].status, HealthCheckStatus.PASS)
+        self.assertEqual(
+            result.checks["fullnode"][0].output, "fullnode is responding correctly"
+        )
         self.assertEqual(result.status, HealthCheckStatus.PASS)
 
     async def test_get_health_check_fullnode_failure(self):
-        """Tests the response we should generate when the fullnode is unhealthy
-        """
-        self.mock_hathor_client.version.side_effect = Exception('error')
-        self.mock_hathor_client._base_url = 'http://localhost:8080'
+        """Tests the response we should generate when the fullnode is unhealthy"""
+        self.mock_hathor_client.version.side_effect = Exception("error")
+        self.mock_hathor_client._base_url = "http://localhost:8080"
 
         self.mock_manager.has_any_miner.return_value = True
         self.mock_manager.has_any_submitted_job_in_period.return_value = True
         job = MagicMock()
         job.is_failed.return_value = False
         job.total_time = 9
-        self.mock_manager.tx_jobs = {'job_id': job}
+        self.mock_manager.tx_jobs = {"job_id": job}
 
         result = await self.health_check.get_health_check()
-        self.assertEqual(result.checks['manager'][0].status, HealthCheckStatus.PASS)
-        self.assertEqual(result.checks['manager'][0].output, 'everything is ok')
-        self.assertEqual(result.checks['fullnode'][0].status, HealthCheckStatus.FAIL)
-        self.assertEqual(result.checks['fullnode'][0].output, 'couldn\'t connect to fullnode')
+        self.assertEqual(result.checks["manager"][0].status, HealthCheckStatus.PASS)
+        self.assertEqual(result.checks["manager"][0].output, "everything is ok")
+        self.assertEqual(result.checks["fullnode"][0].status, HealthCheckStatus.FAIL)
+        self.assertEqual(
+            result.checks["fullnode"][0].output, "couldn't connect to fullnode"
+        )
         self.assertEqual(result.status, HealthCheckStatus.FAIL)
 
     async def test_get_health_check_mining_failure(self):
-        """Tests the response we should generate when the mining is unhealthy
-        """
+        """Tests the response we should generate when the mining is unhealthy"""
         # Mock the implementation of the hathor_client.version.
         async def side_effect():
-            return {'version': '1.0.0'}
+            return {"version": "1.0.0"}
+
         self.mock_hathor_client.version.side_effect = side_effect
-        self.mock_hathor_client._base_url = 'http://localhost:8080'
+        self.mock_hathor_client._base_url = "http://localhost:8080"
 
         self.mock_manager.has_any_miner.return_value = True
         self.mock_manager.has_any_submitted_job_in_period.return_value = False
 
         result = await self.health_check.get_health_check()
-        self.assertEqual(result.checks['manager'][0].status, HealthCheckStatus.FAIL)
-        self.assertEqual(result.checks['manager'][0].output, 'no miners submitted a job in the last 1 hour')
-        self.assertEqual(result.checks['fullnode'][0].status, HealthCheckStatus.PASS)
-        self.assertEqual(result.checks['fullnode'][0].output, 'fullnode is responding correctly')
+        self.assertEqual(result.checks["manager"][0].status, HealthCheckStatus.FAIL)
+        self.assertEqual(
+            result.checks["manager"][0].output,
+            "no miners submitted a job in the last 1 hour",
+        )
+        self.assertEqual(result.checks["fullnode"][0].status, HealthCheckStatus.PASS)
+        self.assertEqual(
+            result.checks["fullnode"][0].output, "fullnode is responding correctly"
+        )
         self.assertEqual(result.status, HealthCheckStatus.FAIL)

--- a/tests/test_healthcheck.py
+++ b/tests/test_healthcheck.py
@@ -2,7 +2,7 @@ from unittest.mock import MagicMock
 
 import asynctest  # type: ignore[import]
 
-from txstratum.healthcheck import (
+from txstratum.healthcheck.healthcheck import (
     ComponentType,
     FullnodeHealthCheck,
     HealthCheck,

--- a/tests/test_healthcheck.py
+++ b/tests/test_healthcheck.py
@@ -91,7 +91,8 @@ class TestMiningHealthCheck(asynctest.TestCase):  # type: ignore[misc]
         self.assertEqual(result.component_type, ComponentType.INTERNAL)
         self.assertEqual(result.status, HealthCheckStatus.FAIL)
         self.assertEqual(
-            result.output, "We had 1 failed jobs and 0 long running jobs in the last 5 minutes"
+            result.output,
+            "We had 1 failed jobs and 0 long running jobs in the last 5 minutes",
         )
 
     async def test_get_health_check_slow_job(self):
@@ -155,7 +156,11 @@ class TestMiningHealthCheck(asynctest.TestCase):  # type: ignore[misc]
         self.assertEqual(result.status, HealthCheckStatus.FAIL)
         self.assertEqual(
             result.output,
-            f"We had no tx_jobs in the last 5 minutes, so we are just returning the last observed status from {mock_date.strftime('%Y-%m-%dT%H:%M:%SZ')}. The output was: We had 1 failed jobs and 0 long running jobs in the last 5 minutes",
+            (
+                "We had no tx_jobs in the last 5 minutes, so we are just returning the last observed status from"
+                f" {mock_date.strftime('%Y-%m-%dT%H:%M:%SZ')}. The output was: We had 1 failed jobs and 0 long"
+                " running jobs in the last 5 minutes"
+            ),
         )
 
 

--- a/tests/test_healthcheck.py
+++ b/tests/test_healthcheck.py
@@ -43,7 +43,7 @@ class TestFullnodeHealthCheck(asynctest.TestCase):  # type: ignore[misc]
         self.assertEqual(result.component_name, "fullnode")
         self.assertEqual(result.component_type, ComponentType.FULLNODE)
         self.assertEqual(result.status, HealthCheckStatus.FAIL)
-        self.assertEqual(result.output, "couldn't connect to fullnode")
+        self.assertEqual(result.output, "couldn't connect to fullnode: error")
         self.assertEqual(result.component_id, "http://localhost:8080")
 
 
@@ -164,7 +164,7 @@ class TestHealthCheck(asynctest.TestCase):  # type: ignore[misc]
         self.assertEqual(result.checks["manager"][0].output, "everything is ok")
         self.assertEqual(result.checks["fullnode"][0].status, HealthCheckStatus.FAIL)
         self.assertEqual(
-            result.checks["fullnode"][0].output, "couldn't connect to fullnode"
+            result.checks["fullnode"][0].output, "couldn't connect to fullnode: error"
         )
         self.assertEqual(result.status, HealthCheckStatus.FAIL)
 

--- a/tests/test_healthcheck.py
+++ b/tests/test_healthcheck.py
@@ -1,0 +1,170 @@
+from unittest.mock import MagicMock
+
+import asynctest
+from txstratum.healthcheck import FullnodeHealthCheck, HealthCheck, MiningHealthCheck, ComponentType, HealthCheckStatus
+
+
+class TestFullnodeHealthCheck(asynctest.TestCase):
+    def setUp(self) -> None:
+        self.mock_hathor_client = MagicMock()
+        self.fullnode_health_check = FullnodeHealthCheck(backend=self.mock_hathor_client)
+
+    async def test_get_health_check_with_a_healthy_fullnode(self):
+        """Test the response we should generated for a healthy fullnode
+        """
+        # Mock the implementation of the hathor_client.version.
+        async def side_effect():
+            return {'version': '1.0.0'}
+        self.mock_hathor_client.version.side_effect = side_effect
+        self.mock_hathor_client._base_url = 'http://localhost:8080'
+
+        result = await self.fullnode_health_check.get_health_check()
+        self.assertEqual(result.component_name, 'fullnode')
+        self.assertEqual(result.component_type, ComponentType.FULLNODE)
+        self.assertEqual(result.status, HealthCheckStatus.PASS)
+        self.assertEqual(result.output, 'fullnode is responding correctly')
+        self.assertEqual(result.component_id, 'http://localhost:8080')
+
+    async def test_get_health_check_with_an_unhealthy_fullnode(self):
+        """Test the response we should generated for an unhealthy fullnode
+        """
+        self.mock_hathor_client.version.side_effect = Exception('error')
+        self.mock_hathor_client._base_url = 'http://localhost:8080'
+
+        result = await self.fullnode_health_check.get_health_check()
+        self.assertEqual(result.component_name, 'fullnode')
+        self.assertEqual(result.component_type, ComponentType.FULLNODE)
+        self.assertEqual(result.status, HealthCheckStatus.FAIL)
+        self.assertEqual(result.output, 'couldn\'t connect to fullnode')
+        self.assertEqual(result.component_id, 'http://localhost:8080')
+
+
+class TestMiningHealthCheck(asynctest.TestCase):
+    def setUp(self):
+        self.manager = MagicMock()
+        self.mining_health_check = MiningHealthCheck(manager=self.manager)
+
+    async def test_get_health_check_no_miners(self):
+        self.manager.has_any_miner.return_value = False
+        result = await self.mining_health_check.get_health_check()
+        self.assertEqual(result.component_name, 'manager')
+        self.assertEqual(result.component_type, ComponentType.INTERNAL)
+        self.assertEqual(result.status, HealthCheckStatus.FAIL)
+        self.assertEqual(result.output, 'no miners connected')
+
+    async def test_get_health_check_no_submitted_job_in_period(self):
+        self.manager.has_any_miner.return_value = True
+        self.manager.has_any_submitted_job_in_period.return_value = False
+        result = await self.mining_health_check.get_health_check()
+        self.assertEqual(result.component_name, 'manager')
+        self.assertEqual(result.component_type, ComponentType.INTERNAL)
+        self.assertEqual(result.status, HealthCheckStatus.FAIL)
+        self.assertEqual(result.output, 'no miners submitted a job in the last 1 hour')
+
+    async def test_get_health_check_failed_job(self):
+        self.manager.has_any_miner.return_value = True
+        self.manager.has_any_submitted_job_in_period.return_value = True
+        job = MagicMock()
+        job.is_failed.return_value = True
+        self.manager.tx_jobs = {'job_id': job}
+        result = await self.mining_health_check.get_health_check()
+        self.assertEqual(result.component_name, 'manager')
+        self.assertEqual(result.component_type, ComponentType.INTERNAL)
+        self.assertEqual(result.status, HealthCheckStatus.FAIL)
+        self.assertEqual(result.output, 'some tx_jobs in the last 5 minutes have failed')
+
+    async def test_get_health_check_slow_job(self):
+        self.manager.has_any_miner.return_value = True
+        self.manager.has_any_submitted_job_in_period.return_value = True
+        job = MagicMock()
+        job.is_failed.return_value = False
+        job.total_time = 11
+        self.manager.tx_jobs = {'job_id': job}
+        result = await self.mining_health_check.get_health_check()
+        self.assertEqual(result.component_name, 'manager')
+        self.assertEqual(result.component_type, ComponentType.INTERNAL)
+        self.assertEqual(result.status, HealthCheckStatus.WARN)
+        self.assertEqual(result.output, 'some tx_jobs in the last 5 minutes took more than 10 seconds to be solved')
+
+    async def test_get_health_check_ok(self):
+        self.manager.has_any_miner.return_value = True
+        self.manager.has_any_submitted_job_in_period.return_value = True
+        job = MagicMock()
+        job.is_failed.return_value = False
+        job.total_time = 9
+        self.manager.tx_jobs = {'job_id': job}
+        result = await self.mining_health_check.get_health_check()
+        self.assertEqual(result.component_name, 'manager')
+        self.assertEqual(result.component_type, ComponentType.INTERNAL)
+        self.assertEqual(result.status, HealthCheckStatus.PASS)
+        self.assertEqual(result.output, 'everything is ok')
+
+
+class TestHealthCheck(asynctest.TestCase):
+    def setUp(self):
+        self.mock_hathor_client = MagicMock()
+        self.mock_manager = MagicMock()
+
+        self.health_check = HealthCheck(manager=self.mock_manager, backend=self.mock_hathor_client)
+
+    async def test_get_health_check_success(self):
+        """Tests the response we should generate when everything is ok
+        """
+        # Mock the implementation of the hathor_client.version.
+        async def side_effect():
+            return {'version': '1.0.0'}
+        self.mock_hathor_client.version.side_effect = side_effect
+        self.mock_hathor_client._base_url = 'http://localhost:8080'
+
+        self.mock_manager.has_any_miner.return_value = True
+        self.mock_manager.has_any_submitted_job_in_period.return_value = True
+        job = MagicMock()
+        job.is_failed.return_value = False
+        job.total_time = 9
+        self.mock_manager.tx_jobs = {'job_id': job}
+
+        result = await self.health_check.get_health_check()
+        self.assertEqual(result.checks['manager'][0].status, HealthCheckStatus.PASS)
+        self.assertEqual(result.checks['manager'][0].output, 'everything is ok')
+        self.assertEqual(result.checks['fullnode'][0].status, HealthCheckStatus.PASS)
+        self.assertEqual(result.checks['fullnode'][0].output, 'fullnode is responding correctly')
+        self.assertEqual(result.status, HealthCheckStatus.PASS)
+
+    async def test_get_health_check_fullnode_failure(self):
+        """Tests the response we should generate when the fullnode is unhealthy
+        """
+        self.mock_hathor_client.version.side_effect = Exception('error')
+        self.mock_hathor_client._base_url = 'http://localhost:8080'
+
+        self.mock_manager.has_any_miner.return_value = True
+        self.mock_manager.has_any_submitted_job_in_period.return_value = True
+        job = MagicMock()
+        job.is_failed.return_value = False
+        job.total_time = 9
+        self.mock_manager.tx_jobs = {'job_id': job}
+
+        result = await self.health_check.get_health_check()
+        self.assertEqual(result.checks['manager'][0].status, HealthCheckStatus.PASS)
+        self.assertEqual(result.checks['manager'][0].output, 'everything is ok')
+        self.assertEqual(result.checks['fullnode'][0].status, HealthCheckStatus.FAIL)
+        self.assertEqual(result.checks['fullnode'][0].output, 'couldn\'t connect to fullnode')
+        self.assertEqual(result.status, HealthCheckStatus.FAIL)
+
+    async def test_get_health_check_mining_failure(self):
+        """Tests the response we should generate when the mining is unhealthy
+        """
+        # Mock the implementation of the hathor_client.version.
+        async def side_effect():
+            return {'version': '1.0.0'}
+        self.mock_hathor_client.version.side_effect = side_effect
+        self.mock_hathor_client._base_url = 'http://localhost:8080'
+
+        self.mock_manager.has_any_miner.return_value = True
+        self.mock_manager.has_any_submitted_job_in_period.return_value = False
+
+        result = await self.health_check.get_health_check()
+        self.assertEqual(result.checks['manager'][0].status, HealthCheckStatus.FAIL)
+        self.assertEqual(result.checks['manager'][0].output, 'no miners submitted a job in the last 1 hour')
+        self.assertEqual(result.checks['fullnode'][0].status, HealthCheckStatus.PASS)
+        self.assertEqual(result.checks['fullnode'][0].output, 'fullnode is responding correctly')
+        self.assertEqual(result.status, HealthCheckStatus.FAIL)

--- a/txstratum/api.py
+++ b/txstratum/api.py
@@ -13,7 +13,7 @@ from structlog import get_logger
 
 import txstratum.time
 from txstratum.exceptions import JobAlreadyExists, NewJobRefused
-from txstratum.healthcheck import HealthCheck
+from txstratum.healthcheck.healthcheck import HealthCheck
 from txstratum.jobs import JobStatus, TxJob
 from txstratum.middleware import create_middleware_version_check
 from txstratum.utils import tx_or_block_from_bytes

--- a/txstratum/api.py
+++ b/txstratum/api.py
@@ -10,10 +10,10 @@ from aiohttp import web
 from hathorlib import TokenCreationTransaction, Transaction
 from hathorlib.exceptions import TxValidationError
 from structlog import get_logger
-from txstratum.healthcheck import HealthCheck
 
 import txstratum.time
 from txstratum.exceptions import JobAlreadyExists, NewJobRefused
+from txstratum.healthcheck import HealthCheck
 from txstratum.jobs import JobStatus, TxJob
 from txstratum.middleware import create_middleware_version_check
 from txstratum.utils import tx_or_block_from_bytes

--- a/txstratum/api.py
+++ b/txstratum/api.py
@@ -88,7 +88,7 @@ class App:
 
     async def health(self, request: web.Request) -> web.Response:
         """Return that the service is running."""
-        health_check_result = self.health_check.get_health_check()
+        health_check_result = await self.health_check.get_health_check()
         http_status = health_check_result.get_http_status_code()
 
         return web.json_response(health_check_result.to_json(), status=http_status)

--- a/txstratum/api.py
+++ b/txstratum/api.py
@@ -62,7 +62,7 @@ class App:
         super().__init__()
         self.log = logger.new()
         self.manager = manager
-        self.health_check = health_check
+        self.health_check_manager = health_check
         self.max_tx_weight: float = max_tx_weight or MAX_TX_WEIGHT
         self.max_output_script_size = max_output_script_size or MAX_OUTPUT_SCRIPT_SIZE
         self.max_timestamp_delta: float = max_timestamp_delta or MAX_TIMESTAMP_DELTA
@@ -78,6 +78,7 @@ class App:
                 )
             ]
         )
+        self.app.router.add_get("/health-check", self.health_check)
         self.app.router.add_get("/health", self.health)
         self.app.router.add_get("/mining-status", self.mining_status)
         self.app.router.add_get("/job-status", self.job_status)
@@ -87,11 +88,16 @@ class App:
         self.fix_invalid_timestamp: bool = fix_invalid_timestamp
 
     async def health(self, request: web.Request) -> web.Response:
-        """Return that the service is running."""
-        health_check_result = await self.health_check.get_health_check()
+        """Return the health check status for the tx-mining-service."""
+        health_check_result = await self.health_check_manager.get_health_check()
         http_status = health_check_result.get_http_status_code()
 
         return web.json_response(health_check_result.to_json(), status=http_status)
+
+    # XXX: DEPRECATED, Use /health instead
+    async def health_check(self, request: web.Request) -> web.Response:
+        """Return that the service is running."""
+        return web.json_response({"success": True})
 
     async def mining_status(self, request: web.Request) -> web.Response:
         """Return status of miners."""

--- a/txstratum/cli.py
+++ b/txstratum/cli.py
@@ -169,7 +169,7 @@ class RunService:
             pubsub=self.pubsub,
             address=args.address,
         )
-        self.health_check = HealthCheck(self.manager)
+        self.health_check = HealthCheck(self.manager, self.backend)
 
     def configure_logging(self, args: Namespace) -> None:
         """Configure logging."""

--- a/txstratum/cli.py
+++ b/txstratum/cli.py
@@ -17,6 +17,7 @@ from structlog import get_logger
 
 from txstratum.api import App
 from txstratum.filters import FileFilter, TOIFilter, TXFilter
+from txstratum.healthcheck import HealthCheck
 from txstratum.manager import TxMiningManager
 from txstratum.pubsub import PubSubManager
 from txstratum.toi_client import TOIAsyncClient
@@ -151,6 +152,7 @@ class RunService:
     manager: TxMiningManager
     loop: AbstractEventLoop
     tx_filters: List[TXFilter]
+    health_check: HealthCheck
 
     def __init__(self, args: Namespace) -> None:
         """Initialize the service."""
@@ -167,6 +169,7 @@ class RunService:
             pubsub=self.pubsub,
             address=args.address,
         )
+        self.health_check = HealthCheck(self.manager)
 
     def configure_logging(self, args: Namespace) -> None:
         """Configure logging."""
@@ -253,6 +256,7 @@ class RunService:
 
         api_app = App(
             self.manager,
+            self.health_check,
             max_tx_weight=self.args.max_tx_weight,
             max_timestamp_delta=self.args.max_timestamp_delta,
             tx_timeout=self.args.tx_timeout,

--- a/txstratum/cli.py
+++ b/txstratum/cli.py
@@ -17,7 +17,7 @@ from structlog import get_logger
 
 from txstratum.api import App
 from txstratum.filters import FileFilter, TOIFilter, TXFilter
-from txstratum.healthcheck import HealthCheck
+from txstratum.healthcheck.healthcheck import HealthCheck
 from txstratum.manager import TxMiningManager
 from txstratum.pubsub import PubSubManager
 from txstratum.toi_client import TOIAsyncClient

--- a/txstratum/healthcheck.py
+++ b/txstratum/healthcheck.py
@@ -1,0 +1,209 @@
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+
+if TYPE_CHECKING:
+    from txstratum.manager import TxMiningManager
+
+
+class ComponentType(str, Enum):
+    """
+    Enum used to store the component types that can be used in the HealthCheckComponentStatus class.
+    """
+    DATASTORE = 'datastore'
+    INTERNAL_COMPONENT = 'internal_component'
+
+
+class HealthCheckStatus(str, Enum):
+    """
+    Enum used to store the component status that can be used in the HealthCheckComponentStatus class.
+    """
+    PASS = 'pass'
+    WARN = 'warn'
+    FAIL = 'fail'
+
+
+@dataclass
+class ComponentHealthCheck:
+    """
+    This class is used to store the result of a health check in a specific component.
+    """
+    component_name: str
+    component_type: ComponentType
+    status: HealthCheckStatus
+    output: str
+    time: Optional[str] = None
+    component_id: Optional[str] = None
+    observed_value: Optional[str] = None
+    observed_unit: Optional[str] = None
+
+    def update(self, new_values: Dict[str, Any]) -> None:
+        """
+        Update the object with the new values passed as kwargs.
+        Also updates the time field with the current time with the format YYYY-MM-DDTHH:mm:ssZ
+        """
+        self.time = datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ')
+
+        for key, value in new_values.items():
+            setattr(self, key, value)
+
+    def to_json(self) -> dict:
+        """
+        Return a dict representation of the object. All field names are converted to camel case.
+        """
+        json = {
+            'componentType': self.component_type.value,
+            'status': self.status.value,
+            'output': self.output
+        }
+
+        if self.component_id:
+            json['componentId'] = self.component_id
+
+        if self.observed_value:
+            assert self.observed_unit is not None, 'observed_unit must be set if observed_value is set'
+
+            json['observedValue'] = self.observed_value
+            json['observedUnit'] = self.observed_unit
+
+        return json
+
+
+@dataclass
+class HealthCheckResult:
+    status: HealthCheckStatus
+    description: str
+    checks: Dict[str, List[ComponentHealthCheck]]
+
+    def get_http_status_code(self) -> int:
+        """
+        Return the HTTP status code for the status.
+        """
+        if self.status == HealthCheckStatus.PASS:
+            return 200
+        elif self.status == HealthCheckStatus.WARN:
+            return 503
+        elif self.status == HealthCheckStatus.FAIL:
+            return 503
+        else:
+            raise ValueError('Invalid status')
+
+    def to_json(self) -> dict:
+        """
+        Return a dict representation of the object. All field names are converted to camel case.
+        """
+        return {
+            'status': self.status.value,
+            'description': self.description,
+            'checks': {k: [c.to_json() for c in v] for k, v in self.checks.items()}
+        }
+
+
+class HealthCheckInterface(ABC):
+    """
+    This is an interface to be used by other classes implementing health checks for components.
+    """
+    @abstractmethod
+    def get_health_check(self) -> ComponentHealthCheck:
+        """
+        Return the health check status for the component.
+        """
+        raise NotImplementedError()
+
+
+class HealthCheck(HealthCheckInterface):
+    """This is the main class that will use the other classes to check the health of the components.
+    It will aggregate the responses into a final object to be returned following our standards.
+    """
+    def __init__(self, manager: "TxMiningManager") -> None:
+        self.health_check_components: List[HealthCheckInterface] = [
+            ManagerHealthCheck(manager)
+        ]
+
+    def get_health_check(self) -> HealthCheckResult:
+        components_health_checks = [c.get_health_check() for c in self.health_check_components]
+        components_status = {c.status for c in components_health_checks}
+
+        overall_status = HealthCheckStatus.PASS
+        if HealthCheckStatus.FAIL in components_status:
+            overall_status = HealthCheckStatus.FAIL
+        elif HealthCheckStatus.WARN in components_status:
+            overall_status = HealthCheckStatus.WARN
+
+        return HealthCheckResult(
+            status=overall_status,
+            description='health of txstratum service',
+            checks={c.component_name: [c] for c in components_health_checks}
+        )
+
+
+# class FullnodeHealthCheck(HealthCheckInterface):
+#     """
+#     This class will check the health of the fullnode by sending a request to its /v1a/health
+#     """
+
+
+class ManagerHealthCheck(HealthCheckInterface):
+    """
+    This class receives a manager instance as parameter and implements a health check method for it that will:
+    - Check that the manager has at least 1 miner
+    - Check that all 'tx_jobs' in the manager in the last 5 minutes have a status of done
+      and have a total_time lesser than 10 seconds.
+
+    If at least one of the 'tx_jobs' has a 'total_time' of more than 10 seconds, the health check
+    will be returned as 'warn'.
+
+    If some of the 'tx_jobs' has status different than 'done', the health check will be returned
+    as 'fail'.
+
+    If there are no miners, the health check will be returned as 'fail'
+    """
+    def __init__(self, manager: "TxMiningManager") -> None:
+        self.manager = manager
+        self.last_manager_status = ComponentHealthCheck(
+            component_name='manager',
+            component_type=ComponentType.INTERNAL_COMPONENT,
+            status=HealthCheckStatus.PASS,
+            output='everything is ok'
+        )
+
+    def get_health_check(self) -> ComponentHealthCheck:
+        """
+        Return the manager health check status.
+        """
+        if not self.manager.has_any_miner():
+            self.last_manager_status.update({
+                'status': HealthCheckStatus.FAIL,
+                'output': 'no miners connected'
+            })
+
+            return self.last_manager_status
+
+        if not self.manager.tx_jobs:
+            # We just return the last status in case there are no jobs in the last 5 minutes
+            return self.last_manager_status
+
+        for job in self.manager.tx_jobs.values():
+            if job.is_failed():
+                self.last_manager_status.update({
+                    'status': HealthCheckStatus.FAIL,
+                    'output': 'some tx_jobs in the last 5 minutes have failed'
+                })
+
+                return self.last_manager_status
+            if job.total_time > 10:
+                self.last_manager_status.update({
+                    'status': HealthCheckStatus.WARN,
+                    'output': 'some tx_jobs in the last 5 minutes took more than 10 seconds to be solved'
+                })
+
+                return self.last_manager_status
+
+        self.last_manager_status.update({
+            'status': HealthCheckStatus.PASS,
+            'output': 'everything is ok'
+        })
+
+        return self.last_manager_status

--- a/txstratum/healthcheck.py
+++ b/txstratum/healthcheck.py
@@ -140,7 +140,7 @@ class HealthCheck(HealthCheckInterface):
 
         return HealthCheckResult(
             status=overall_status,
-            description='health of txstratum service',
+            description='health of tx-mining-service',
             checks={c.component_name: [c] for c in components_health_checks}
         )
 
@@ -159,7 +159,8 @@ class FullnodeHealthCheck(HealthCheckInterface):
         health_check = ComponentHealthCheck(
             component_name='fullnode',
             component_type=ComponentType.FULLNODE,
-            component_id=self.backend._base_url,  # TODO: Ideally we should not use private fields
+            # TODO: Ideally we should not use private fields. We'll fix this when fixing line 170
+            component_id=self.backend._base_url,
             status=HealthCheckStatus.PASS,
             time=datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'),
             output='fullnode is responding correctly'

--- a/txstratum/healthcheck.py
+++ b/txstratum/healthcheck.py
@@ -83,16 +83,24 @@ class HealthCheckResult:
     description: str
     checks: Dict[str, List[ComponentHealthCheck]]
 
+    def __post_init__(self) -> None:
+        """Perform some validations after the object is initialized."""
+        # Make sure the checks dict is not empty
+        if not self.checks:
+            raise ValueError("checks dict cannot be empty")
+
+        # Make sure the status is valid
+        if self.status not in HealthCheckStatus:
+            raise ValueError("Invalid status")
+
     def get_http_status_code(self) -> int:
         """Return the HTTP status code for the status."""
-        if self.status == HealthCheckStatus.PASS:
+        if self.status in [HealthCheckStatus.PASS]:
             return 200
-        elif self.status == HealthCheckStatus.WARN:
-            return 503
-        elif self.status == HealthCheckStatus.FAIL:
+        elif self.status in [HealthCheckStatus.WARN, HealthCheckStatus.FAIL]:
             return 503
         else:
-            raise ValueError("Invalid status")
+            raise ValueError(f"Missing treatment for status {self.status}")
 
     def to_json(self) -> Dict[str, Any]:
         """Return a dict representation of the object. All field names are converted to camel case."""

--- a/txstratum/healthcheck.py
+++ b/txstratum/healthcheck.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+import asyncio
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
@@ -135,9 +136,7 @@ class HealthCheck:
 
     async def get_health_check(self) -> HealthCheckResult:
         """Return the health check status for the tx-mining-service."""
-        components_health_checks = [
-            await c.get_health_check() for c in self.health_check_components
-        ]
+        components_health_checks = await asyncio.gather(*[c.get_health_check() for c in self.health_check_components])
         components_status = {c.status for c in components_health_checks}
 
         overall_status = HealthCheckStatus.PASS

--- a/txstratum/healthcheck.py
+++ b/txstratum/healthcheck.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from hathorlib.client import HathorClient
 
 if TYPE_CHECKING:
     from txstratum.manager import TxMiningManager
@@ -13,7 +14,8 @@ class ComponentType(str, Enum):
     Enum used to store the component types that can be used in the HealthCheckComponentStatus class.
     """
     DATASTORE = 'datastore'
-    INTERNAL_COMPONENT = 'internal_component'
+    INTERNAL = 'internal'
+    FULLNODE = 'fullnode'
 
 
 class HealthCheckStatus(str, Enum):
@@ -58,6 +60,9 @@ class ComponentHealthCheck:
             'status': self.status.value,
             'output': self.output
         }
+
+        if self.time:
+            json['time'] = self.time
 
         if self.component_id:
             json['componentId'] = self.component_id
@@ -106,7 +111,7 @@ class HealthCheckInterface(ABC):
     This is an interface to be used by other classes implementing health checks for components.
     """
     @abstractmethod
-    def get_health_check(self) -> ComponentHealthCheck:
+    async def get_health_check(self) -> ComponentHealthCheck:
         """
         Return the health check status for the component.
         """
@@ -117,13 +122,14 @@ class HealthCheck(HealthCheckInterface):
     """This is the main class that will use the other classes to check the health of the components.
     It will aggregate the responses into a final object to be returned following our standards.
     """
-    def __init__(self, manager: "TxMiningManager") -> None:
+    def __init__(self, manager: "TxMiningManager", backend: "HathorClient") -> None:
         self.health_check_components: List[HealthCheckInterface] = [
-            ManagerHealthCheck(manager)
+            MiningHealthCheck(manager),
+            FullnodeHealthCheck(backend)
         ]
 
-    def get_health_check(self) -> HealthCheckResult:
-        components_health_checks = [c.get_health_check() for c in self.health_check_components]
+    async def get_health_check(self) -> HealthCheckResult:
+        components_health_checks = [await c.get_health_check() for c in self.health_check_components]
         components_status = {c.status for c in components_health_checks}
 
         overall_status = HealthCheckStatus.PASS
@@ -139,18 +145,46 @@ class HealthCheck(HealthCheckInterface):
         )
 
 
-# class FullnodeHealthCheck(HealthCheckInterface):
-#     """
-#     This class will check the health of the fullnode by sending a request to its /v1a/health
-#     """
+class FullnodeHealthCheck(HealthCheckInterface):
+    """
+    This class will check the health of the fullnode by sending a request to its /v1a/health
+    """
+    def __init__(self, backend: "HathorClient") -> None:
+        self.backend = backend
+
+    async def get_health_check(self) -> ComponentHealthCheck:
+        """
+        Return the fullnode health check status.
+        """
+        health_check = ComponentHealthCheck(
+            component_name='fullnode',
+            component_type=ComponentType.FULLNODE,
+            component_id=self.backend._base_url,  # TODO: Ideally we should not use private fields
+            status=HealthCheckStatus.PASS,
+            time=datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'),
+            output='fullnode is responding correctly'
+        )
+
+        try:
+            # TODO: We need to get the health information from the fullnode, but it's not implemented yet
+            await self.backend.version()
+
+            return health_check
+        except Exception:
+            health_check.status = HealthCheckStatus.FAIL
+            health_check.output = 'couldn\'t connect to fullnode'
+
+            return health_check
 
 
-class ManagerHealthCheck(HealthCheckInterface):
+class MiningHealthCheck(HealthCheckInterface):
     """
     This class receives a manager instance as parameter and implements a health check method for it that will:
     - Check that the manager has at least 1 miner
     - Check that all 'tx_jobs' in the manager in the last 5 minutes have a status of done
       and have a total_time lesser than 10 seconds.
+    - Check that all miners have submitted at least 1 job in the last 1 hour.
+      Note that subimitting a job doesn't mean solving a tx.
 
     If at least one of the 'tx_jobs' has a 'total_time' of more than 10 seconds, the health check
     will be returned as 'warn'.
@@ -159,30 +193,43 @@ class ManagerHealthCheck(HealthCheckInterface):
     as 'fail'.
 
     If there are no miners, the health check will be returned as 'fail'
+
+    If there are miners, but any of them has submitted a job in the last 1 hour, the health check
+    will be returned as 'fail'
     """
     def __init__(self, manager: "TxMiningManager") -> None:
         self.manager = manager
         self.last_manager_status = ComponentHealthCheck(
             component_name='manager',
-            component_type=ComponentType.INTERNAL_COMPONENT,
+            component_type=ComponentType.INTERNAL,
             status=HealthCheckStatus.PASS,
             output='everything is ok'
         )
 
-    def get_health_check(self) -> ComponentHealthCheck:
+    async def get_health_check(self) -> ComponentHealthCheck:
         """
         Return the manager health check status.
         """
+        # Check that the manager has at least 1 miner
         if not self.manager.has_any_miner():
-            self.last_manager_status.update({
-                'status': HealthCheckStatus.FAIL,
-                'output': 'no miners connected'
-            })
+            return ComponentHealthCheck(
+                component_name='manager',
+                component_type=ComponentType.INTERNAL,
+                status=HealthCheckStatus.FAIL,
+                output='no miners connected'
+            )
 
-            return self.last_manager_status
+        # Check that all the miners submitted in the last 1 hour. If not, return failed.
+        if not self.manager.has_any_submitted_job_in_period(period=3600):
+            return ComponentHealthCheck(
+                component_name='manager',
+                component_type=ComponentType.INTERNAL,
+                status=HealthCheckStatus.FAIL,
+                output='no miners submitted a job in the last 1 hour'
+            )
 
         if not self.manager.tx_jobs:
-            # We just return the last status in case there are no jobs in the last 5 minutes
+            # We just return the last saved status in case there are no jobs in the last 5 minutes
             return self.last_manager_status
 
         for job in self.manager.tx_jobs.values():

--- a/txstratum/healthcheck/healthcheck.py
+++ b/txstratum/healthcheck/healthcheck.py
@@ -135,10 +135,8 @@ class MiningHealthCheck(ComponentHealthCheckInterface):
         for job in self.manager.tx_jobs.values():
             if job.is_failed():
                 self.last_manager_status.update(
-                    {
-                        "status": HealthCheckStatus.FAIL,
-                        "output": "some tx_jobs in the last 5 minutes have failed",
-                    }
+                    status=HealthCheckStatus.FAIL,
+                    output="some tx_jobs in the last 5 minutes have failed",
                 )
 
                 return self.last_manager_status
@@ -149,16 +147,14 @@ class MiningHealthCheck(ComponentHealthCheckInterface):
 
                 if job.total_time > self.JOB_MINING_TIME_THRESHOLD:
                     self.last_manager_status.update(
-                        {
-                            "status": HealthCheckStatus.WARN,
-                            "output": "some tx_jobs in the last 5 minutes took more than 10 seconds to be solved",
-                        }
+                        status=HealthCheckStatus.WARN,
+                        output="some tx_jobs in the last 5 minutes took more than 10 seconds to be solved",
                     )
 
                     return self.last_manager_status
 
         self.last_manager_status.update(
-            {"status": HealthCheckStatus.PASS, "output": "everything is ok"}
+            status=HealthCheckStatus.PASS, output="everything is ok"
         )
 
         return self.last_manager_status

--- a/txstratum/healthcheck/healthcheck.py
+++ b/txstratum/healthcheck/healthcheck.py
@@ -52,6 +52,8 @@ class HealthCheck:
 class FullnodeHealthCheck(ComponentHealthCheckInterface):
     """This class will check the health of the fullnode by sending a request to its /v1a/health."""
 
+    COMPONENT_NAME = "fullnode"
+
     def __init__(self, backend: "HathorClient") -> None:
         """Init the class with the fullnode backend."""
         self.backend = backend
@@ -59,7 +61,7 @@ class FullnodeHealthCheck(ComponentHealthCheckInterface):
     async def get_health_check(self) -> ComponentHealthCheck:
         """Return the fullnode health check status."""
         health_check = ComponentHealthCheck(
-            component_name="fullnode",
+            component_name=self.COMPONENT_NAME,
             component_type=ComponentType.FULLNODE,
             # TODO: Ideally we should not use private fields. We'll fix this when fixing line 170
             component_id=self.backend._base_url,

--- a/txstratum/healthcheck/healthcheck.py
+++ b/txstratum/healthcheck/healthcheck.py
@@ -1,124 +1,13 @@
-from abc import ABC, abstractmethod
 import asyncio
-from dataclasses import dataclass
 from datetime import datetime
-from enum import Enum
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, List
 
 from hathorlib.client import HathorClient
 
+from txstratum.healthcheck.models import ComponentHealthCheck, ComponentHealthCheckInterface, ComponentType, HealthCheckResult, HealthCheckStatus
+
 if TYPE_CHECKING:
     from txstratum.manager import TxMiningManager
-
-
-class ComponentType(str, Enum):
-    """Enum used to store the component types that can be used in the HealthCheckComponentStatus class."""
-
-    DATASTORE = "datastore"
-    INTERNAL = "internal"
-    FULLNODE = "fullnode"
-
-
-class HealthCheckStatus(str, Enum):
-    """Enum used to store the component status that can be used in the HealthCheckComponentStatus class."""
-
-    PASS = "pass"
-    WARN = "warn"
-    FAIL = "fail"
-
-
-@dataclass
-class ComponentHealthCheck:
-    """This class is used to store the result of a health check in a specific component."""
-
-    component_name: str
-    component_type: ComponentType
-    status: HealthCheckStatus
-    output: str
-    time: Optional[str] = None
-    component_id: Optional[str] = None
-    observed_value: Optional[str] = None
-    observed_unit: Optional[str] = None
-
-    def update(self, new_values: Dict[str, Any]) -> None:
-        """
-        Update the object with the new values passed as kwargs.
-
-        Also updates the time field with the current time with the format YYYY-MM-DDTHH:mm:ssZ
-        """
-        self.time = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
-
-        for key, value in new_values.items():
-            setattr(self, key, value)
-
-    def to_json(self) -> Dict[str, str]:
-        """Return a dict representation of the object. All field names are converted to camel case."""
-        json = {
-            "componentType": self.component_type.value,
-            "status": self.status.value,
-            "output": self.output,
-        }
-
-        if self.time:
-            json["time"] = self.time
-
-        if self.component_id:
-            json["componentId"] = self.component_id
-
-        if self.observed_value:
-            assert (
-                self.observed_unit is not None
-            ), "observed_unit must be set if observed_value is set"
-
-            json["observedValue"] = self.observed_value
-            json["observedUnit"] = self.observed_unit
-
-        return json
-
-
-@dataclass
-class HealthCheckResult:
-    """This class is used to store the result of a health check in the tx-mining-service."""
-
-    status: HealthCheckStatus
-    description: str
-    checks: Dict[str, List[ComponentHealthCheck]]
-
-    def __post_init__(self) -> None:
-        """Perform some validations after the object is initialized."""
-        # Make sure the checks dict is not empty
-        if not self.checks:
-            raise ValueError("checks dict cannot be empty")
-
-        # Make sure the status is valid
-        if self.status not in HealthCheckStatus:
-            raise ValueError("Invalid status")
-
-    def get_http_status_code(self) -> int:
-        """Return the HTTP status code for the status."""
-        if self.status in [HealthCheckStatus.PASS]:
-            return 200
-        elif self.status in [HealthCheckStatus.WARN, HealthCheckStatus.FAIL]:
-            return 503
-        else:
-            raise ValueError(f"Missing treatment for status {self.status}")
-
-    def to_json(self) -> Dict[str, Any]:
-        """Return a dict representation of the object. All field names are converted to camel case."""
-        return {
-            "status": self.status.value,
-            "description": self.description,
-            "checks": {k: [c.to_json() for c in v] for k, v in self.checks.items()},
-        }
-
-
-class ComponentHealthCheckInterface(ABC):
-    """This is an interface to be used by other classes implementing health checks for components."""
-
-    @abstractmethod
-    async def get_health_check(self) -> ComponentHealthCheck:
-        """Return the health check status for the component."""
-        raise NotImplementedError()
 
 
 class HealthCheck:

--- a/txstratum/healthcheck/healthcheck.py
+++ b/txstratum/healthcheck/healthcheck.py
@@ -63,7 +63,8 @@ class FullnodeHealthCheck(ComponentHealthCheckInterface):
         health_check = ComponentHealthCheck(
             component_name=self.COMPONENT_NAME,
             component_type=ComponentType.FULLNODE,
-            # TODO: Ideally we should not use private fields. We'll fix this when fixing line 170
+            # TODO: Ideally we should not use private fields.
+            #   We'll fix this when fixing line 74 below about getting the health information from the fullnode.
             component_id=self.backend._base_url,
             status=HealthCheckStatus.PASS,
             time=datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
@@ -96,12 +97,12 @@ class MiningHealthCheck(ComponentHealthCheckInterface):
     If at least one of the 'tx_jobs' has a 'total_time' of more than 10 seconds, the health check
     will be returned as 'warn'.
 
-    If some of the 'tx_jobs' has status different than 'done', the health check will be returned
+    If any of the 'tx_jobs' has status different than 'done', the health check will be returned
     as 'fail'.
 
     If there are no miners, the health check will be returned as 'fail'
 
-    If there are miners, but any of them has submitted a job in the last 1 hour, the health check
+    If there are miners, but none of them has submitted a job in the last 1 hour, the health check
     will be returned as 'fail'
     """
 

--- a/txstratum/healthcheck/healthcheck.py
+++ b/txstratum/healthcheck/healthcheck.py
@@ -65,9 +65,9 @@ class FullnodeHealthCheck(ComponentHealthCheckInterface):
             await self.backend.version()
 
             return health_check
-        except Exception:
+        except Exception as e:
             health_check.status = HealthCheckStatus.FAIL
-            health_check.output = "couldn't connect to fullnode"
+            health_check.output = f"couldn't connect to fullnode: {str(e)}"
 
             return health_check
 

--- a/txstratum/healthcheck/healthcheck.py
+++ b/txstratum/healthcheck/healthcheck.py
@@ -4,7 +4,13 @@ from typing import TYPE_CHECKING, List
 
 from hathorlib.client import HathorClient
 
-from txstratum.healthcheck.models import ComponentHealthCheck, ComponentHealthCheckInterface, ComponentType, HealthCheckResult, HealthCheckStatus
+from txstratum.healthcheck.models import (
+    ComponentHealthCheck,
+    ComponentHealthCheckInterface,
+    ComponentType,
+    HealthCheckResult,
+    HealthCheckStatus,
+)
 
 if TYPE_CHECKING:
     from txstratum.manager import TxMiningManager
@@ -25,7 +31,9 @@ class HealthCheck:
 
     async def get_health_check(self) -> HealthCheckResult:
         """Return the health check status for the tx-mining-service."""
-        components_health_checks = await asyncio.gather(*[c.get_health_check() for c in self.health_check_components])
+        components_health_checks = await asyncio.gather(
+            *[c.get_health_check() for c in self.health_check_components]
+        )
         components_status = {c.status for c in components_health_checks}
 
         overall_status = HealthCheckStatus.PASS
@@ -121,7 +129,9 @@ class MiningHealthCheck(ComponentHealthCheckInterface):
             )
 
         # Check that all the miners submitted in the last 1 hour. If not, return failed.
-        if not self.manager.has_any_submitted_job_in_period(period=self.NO_JOBS_SUBMITTED_THRESHOLD):
+        if not self.manager.has_any_submitted_job_in_period(
+            period=self.NO_JOBS_SUBMITTED_THRESHOLD
+        ):
             return ComponentHealthCheck(
                 component_name=self.COMPONENT_NAME,
                 component_type=ComponentType.INTERNAL,
@@ -134,7 +144,10 @@ class MiningHealthCheck(ComponentHealthCheckInterface):
                 component_name=self.COMPONENT_NAME,
                 component_type=ComponentType.INTERNAL,
                 status=self.last_manager_status.status,
-                output=f"We had no tx_jobs in the last 5 minutes, so we are just returning the last observed status from {self.last_manager_status.time}. The output was: {self.last_manager_status.output}"
+                output=(
+                    "We had no tx_jobs in the last 5 minutes, so we are just returning the last observed"
+                    f" status from {self.last_manager_status.time}. The output was: {self.last_manager_status.output}"
+                ),
             )
 
         failed_jobs = []
@@ -156,7 +169,10 @@ class MiningHealthCheck(ComponentHealthCheckInterface):
                 status=HealthCheckStatus.FAIL
                 if failed_jobs
                 else HealthCheckStatus.WARN,
-                output=f"We had {len(failed_jobs)} failed jobs and {len(long_running_jobs)} long running jobs in the last 5 minutes",
+                output=(
+                    f"We had {len(failed_jobs)} failed jobs and {len(long_running_jobs)}"
+                    " long running jobs in the last 5 minutes"
+                ),
             )
 
             return self.last_manager_status

--- a/txstratum/healthcheck/healthcheck.py
+++ b/txstratum/healthcheck/healthcheck.py
@@ -57,7 +57,7 @@ class FullnodeHealthCheck(ComponentHealthCheckInterface):
             component_id=self.backend._base_url,
             status=HealthCheckStatus.PASS,
             time=datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
-            output="fullnode is responding correctly",
+            output="Fullnode is responding correctly",
         )
 
         try:
@@ -67,7 +67,7 @@ class FullnodeHealthCheck(ComponentHealthCheckInterface):
             return health_check
         except Exception as e:
             health_check.status = HealthCheckStatus.FAIL
-            health_check.output = f"couldn't connect to fullnode: {str(e)}"
+            health_check.output = f"Couldn't connect to fullnode: {str(e)}"
 
             return health_check
 
@@ -117,7 +117,7 @@ class MiningHealthCheck(ComponentHealthCheckInterface):
                 component_name=self.COMPONENT_NAME,
                 component_type=ComponentType.INTERNAL,
                 status=HealthCheckStatus.FAIL,
-                output="no miners connected",
+                output="No miners connected",
             )
 
         # Check that all the miners submitted in the last 1 hour. If not, return failed.
@@ -126,12 +126,16 @@ class MiningHealthCheck(ComponentHealthCheckInterface):
                 component_name=self.COMPONENT_NAME,
                 component_type=ComponentType.INTERNAL,
                 status=HealthCheckStatus.FAIL,
-                output="no miners submitted a job in the last 1 hour",
+                output="No miners submitted a job in the last 1 hour",
             )
 
         if not self.manager.tx_jobs:
-            # We just return the last saved status in case there are no jobs in the last 5 minutes
-            return self.last_manager_status
+            return ComponentHealthCheck(
+                component_name=self.COMPONENT_NAME,
+                component_type=ComponentType.INTERNAL,
+                status=self.last_manager_status.status,
+                output=f"We had no tx_jobs in the last 5 minutes, so we are just returning the last observed status from {self.last_manager_status.time}. The output was: {self.last_manager_status.output}"
+            )
 
         failed_jobs = []
         long_running_jobs = []
@@ -152,13 +156,13 @@ class MiningHealthCheck(ComponentHealthCheckInterface):
                 status=HealthCheckStatus.FAIL
                 if failed_jobs
                 else HealthCheckStatus.WARN,
-                output=f"we had {len(failed_jobs)} failed jobs and {len(long_running_jobs)} long running jobs in the last 5 minutes",
+                output=f"We had {len(failed_jobs)} failed jobs and {len(long_running_jobs)} long running jobs in the last 5 minutes",
             )
 
             return self.last_manager_status
 
         self.last_manager_status.update(
-            status=HealthCheckStatus.PASS, output="everything is ok"
+            status=HealthCheckStatus.PASS, output="Everything is ok"
         )
 
         return self.last_manager_status

--- a/txstratum/healthcheck/models.py
+++ b/txstratum/healthcheck/models.py
@@ -33,7 +33,7 @@ class ComponentHealthCheck:
     observed_value: Optional[str] = None
     observed_unit: Optional[str] = None
 
-    def update(self, new_values: Dict[str, Any]) -> None:
+    def update(self, **new_values: Any) -> None:
         """
         Update the object with the new values passed as kwargs.
 

--- a/txstratum/healthcheck/models.py
+++ b/txstratum/healthcheck/models.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
+
 class ComponentType(str, Enum):
     """Enum used to store the component types that can be used in the HealthCheckComponentStatus class."""
 
@@ -112,4 +113,3 @@ class ComponentHealthCheckInterface(ABC):
     async def get_health_check(self) -> ComponentHealthCheck:
         """Return the health check status for the component."""
         raise NotImplementedError()
-

--- a/txstratum/healthcheck/models.py
+++ b/txstratum/healthcheck/models.py
@@ -1,0 +1,115 @@
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+class ComponentType(str, Enum):
+    """Enum used to store the component types that can be used in the HealthCheckComponentStatus class."""
+
+    DATASTORE = "datastore"
+    INTERNAL = "internal"
+    FULLNODE = "fullnode"
+
+
+class HealthCheckStatus(str, Enum):
+    """Enum used to store the component status that can be used in the HealthCheckComponentStatus class."""
+
+    PASS = "pass"
+    WARN = "warn"
+    FAIL = "fail"
+
+
+@dataclass
+class ComponentHealthCheck:
+    """This class is used to store the result of a health check in a specific component."""
+
+    component_name: str
+    component_type: ComponentType
+    status: HealthCheckStatus
+    output: str
+    time: Optional[str] = None
+    component_id: Optional[str] = None
+    observed_value: Optional[str] = None
+    observed_unit: Optional[str] = None
+
+    def update(self, new_values: Dict[str, Any]) -> None:
+        """
+        Update the object with the new values passed as kwargs.
+
+        Also updates the time field with the current time with the format YYYY-MM-DDTHH:mm:ssZ
+        """
+        self.time = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+
+        for key, value in new_values.items():
+            setattr(self, key, value)
+
+    def to_json(self) -> Dict[str, str]:
+        """Return a dict representation of the object. All field names are converted to camel case."""
+        json = {
+            "componentType": self.component_type.value,
+            "status": self.status.value,
+            "output": self.output,
+        }
+
+        if self.time:
+            json["time"] = self.time
+
+        if self.component_id:
+            json["componentId"] = self.component_id
+
+        if self.observed_value:
+            assert (
+                self.observed_unit is not None
+            ), "observed_unit must be set if observed_value is set"
+
+            json["observedValue"] = self.observed_value
+            json["observedUnit"] = self.observed_unit
+
+        return json
+
+
+@dataclass
+class HealthCheckResult:
+    """This class is used to store the result of a health check in the tx-mining-service."""
+
+    status: HealthCheckStatus
+    description: str
+    checks: Dict[str, List[ComponentHealthCheck]]
+
+    def __post_init__(self) -> None:
+        """Perform some validations after the object is initialized."""
+        # Make sure the checks dict is not empty
+        if not self.checks:
+            raise ValueError("checks dict cannot be empty")
+
+        # Make sure the status is valid
+        if self.status not in HealthCheckStatus:
+            raise ValueError("Invalid status")
+
+    def get_http_status_code(self) -> int:
+        """Return the HTTP status code for the status."""
+        if self.status in [HealthCheckStatus.PASS]:
+            return 200
+        elif self.status in [HealthCheckStatus.WARN, HealthCheckStatus.FAIL]:
+            return 503
+        else:
+            raise ValueError(f"Missing treatment for status {self.status}")
+
+    def to_json(self) -> Dict[str, Any]:
+        """Return a dict representation of the object. All field names are converted to camel case."""
+        return {
+            "status": self.status.value,
+            "description": self.description,
+            "checks": {k: [c.to_json() for c in v] for k, v in self.checks.items()},
+        }
+
+
+class ComponentHealthCheckInterface(ABC):
+    """This is an interface to be used by other classes implementing health checks for components."""
+
+    @abstractmethod
+    async def get_health_check(self) -> ComponentHealthCheck:
+        """Return the health check status for the component."""
+        raise NotImplementedError()
+

--- a/txstratum/jobs.py
+++ b/txstratum/jobs.py
@@ -83,6 +83,10 @@ class TxJob:
         """Return True if job has any status that indicates failure."""
         return self.status in [JobStatus.FAILED, JobStatus.TIMEOUT, JobStatus.CANCELLED]
 
+    def is_done(self) -> bool:
+        """Return True if job has any status that indicates success."""
+        return self.status in [JobStatus.DONE]
+
     def get_tx(self) -> BaseTransaction:
         """Return the Transaction object of this job."""
         return self._tx

--- a/txstratum/jobs.py
+++ b/txstratum/jobs.py
@@ -79,6 +79,10 @@ class TxJob:
         self._timeout_timer: Optional[TimerHandle] = None
         self._cleanup_timer: Optional[TimerHandle] = None
 
+    def is_failed(self) -> bool:
+        """Return True if job has any status that indicates failure."""
+        return self.status in [JobStatus.FAILED, JobStatus.TIMEOUT, JobStatus.CANCELLED]
+
     def get_tx(self) -> BaseTransaction:
         """Return the Transaction object of this job."""
         return self._tx

--- a/txstratum/manager.py
+++ b/txstratum/manager.py
@@ -122,7 +122,7 @@ class TxMiningManager:
         """Return True if there is at least one miner connected."""
         return len(self.miners) > 0
 
-    def has_any_submitted_job_in_period(self, period: int ) -> bool:
+    def has_any_submitted_job_in_period(self, period: int) -> bool:
         """Return True if there is at least one miner that submitted a job in the last `period` seconds."""
         now = txstratum.time.time()
 

--- a/txstratum/manager.py
+++ b/txstratum/manager.py
@@ -122,6 +122,15 @@ class TxMiningManager:
         """Return True if there is at least one miner connected."""
         return len(self.miners) > 0
 
+    def has_any_submitted_job_in_period(self, period: int ) -> bool:
+        """Return True if there is at least one miner that submitted a job in the last `period` seconds."""
+        now = txstratum.time.time()
+
+        for miner in self.miners.values():
+            if miner.last_submit_at > 0 and now - miner.last_submit_at < period:
+                return True
+        return False
+
     def shutdown(self) -> None:
         """Tasks to be executed before the service is shut down."""
         self.refuse_new_jobs = True

--- a/txstratum/manager.py
+++ b/txstratum/manager.py
@@ -118,6 +118,10 @@ class TxMiningManager:
         self.connections.pop(protocol.miner_id)
         self.miners.pop(protocol.miner_id, None)
 
+    def has_any_miner(self) -> bool:
+        """Return True if there is at least one miner connected."""
+        return len(self.miners) > 0
+
     def shutdown(self) -> None:
         """Tasks to be executed before the service is shut down."""
         self.refuse_new_jobs = True


### PR DESCRIPTION
### Acceptance Criteria

We should have a new `/health` endpoint, that will implement a more complex health check which includes:

- Checking that there is at least 1 miner connected
- Checking that the miners have at least 1 job submitted in the last hour (submitting a job is different than mining a transaction, there should be submitted jobs even if no transactions are being mined)
- Checking that none of the jobs in the last 5 minutes failed
- Checking that the jobs aren't taking more than 10 seconds to be mined
- Checking the health of the Fullnode
    - For now we will only make sure its `/v1a/version` endpoint is responding. In future PRs we will use the new yet-to-be-implemented `/v1a/health` endpoint of hathor-core.