### PR TITLE
feat: implement task to estimate RTT value for each miner

### DIFF
--- a/tests/fixtures/expected_prometheus_metrics.prom
+++ b/tests/fixtures/expected_prometheus_metrics.prom
@@ -21,8 +21,8 @@ tx_queue 2.0
 block_template_error 1.0
 # HELP miner_rtt Miner RTT
 # TYPE miner_rtt gauge
-miner_rtt{miner_address="abc123"} 0.0
-miner_rtt{miner_address="def456"} 0.0
+miner_rtt{miner_address="abc123",miner_id="id1"} 0.0
+miner_rtt{miner_address="def456",miner_id="id2"} 0.0
 # HELP txs_jobs_received_total Number of transactions received by the API
 # TYPE txs_jobs_received_total counter
 txs_jobs_received_total 0.0
@@ -31,10 +31,10 @@ txs_jobs_received_total 0.0
 txs_jobs_received_created 1.642511672616624e+09
 # HELP txs_solved_total Number of solved transactions
 # TYPE txs_solved_total counter
-txs_solved_total{miner_address="abc123",miner_type="cpuminer"} 1.0
+txs_solved_total{miner_address="abc123",miner_id="id1",miner_type="cpuminer"} 1.0
 # HELP txs_solved_created Number of solved transactions
 # TYPE txs_solved_created gauge
-txs_solved_created{miner_address="abc123",miner_type="cpuminer"} 1.6425116730388892e+09
+txs_solved_created{miner_address="abc123",miner_id="id2",miner_type="cpuminer"} 1.6425116730388892e+09
 # HELP txs_solved_weight Txs solved histogram by tx weight
 # TYPE txs_solved_weight histogram
 txs_solved_weight_bucket{le="17.0",miner_type="cpuminer"} 0.0

--- a/tests/fixtures/expected_prometheus_metrics.prom
+++ b/tests/fixtures/expected_prometheus_metrics.prom
@@ -19,6 +19,10 @@ tx_queue 2.0
 # HELP block_template_error Number of errors updating block template
 # TYPE block_template_error gauge
 block_template_error 1.0
+# HELP miner_rtt Miner RTT
+# TYPE miner_rtt gauge
+miner_rtt{miner_address="abc123"} 0.0
+miner_rtt{miner_address="def456"} 0.0
 # HELP txs_jobs_received_total Number of transactions received by the API
 # TYPE txs_jobs_received_total counter
 txs_jobs_received_total 0.0

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -755,6 +755,10 @@ class ManagerTestCase(unittest.TestCase):
         # and that they were all the same txJob
         for c in conn.send_request.mock_calls:
             args = c[1]
+            if args[0] == "client.get_version":
+                # We now have a periodic task to get miner version
+                # in order to estimate rtt, so we must skip this request
+                continue
             job_data = args[1]
             self.assertEqual(job_data["clean"], False)
             self.assertEqual(

--- a/tests/test_prometheus.py
+++ b/tests/test_prometheus.py
@@ -75,12 +75,16 @@ class ManagerTestCase(asynctest.TestCase):  # type: ignore[misc]
 
     async def test_update_metrics(self):
         protocol = StratumProtocol(self.manager)
+        # Force miner_id instead of using the random one to validate in the prometheus fixture
+        protocol.miner_id = "id1"
         protocol.miner_address_str = "abc123"
         protocol.miner_version = "cpuminer/1.0"
         self.manager.miners["miner1"] = protocol
         self.pubsub.emit(TxMiningEvents.PROTOCOL_MINER_SUBSCRIBED, protocol)
 
         protocol2 = StratumProtocol(self.manager)
+        # Force miner_id instead of using the random one to validate in the prometheus fixture
+        protocol2.miner_id = "id2"
         protocol2.miner_address_str = "def456"
         protocol2.miner_version = "cpuminer/2.0"
         self.manager.miners["miner2"] = protocol2

--- a/txstratum/prometheus.py
+++ b/txstratum/prometheus.py
@@ -198,8 +198,9 @@ class BasePrometheusExporter:
         protocol = cast(StratumProtocol, obj["protocol"])
 
         METRICS_PUBSUB["txs_solved"].labels(
-            miner_type=protocol.miner_type, miner_address=protocol.miner_address_str,
-            miner_id=protocol.miner_id
+            miner_type=protocol.miner_type,
+            miner_address=protocol.miner_address_str,
+            miner_id=protocol.miner_id,
         ).inc()
 
         METRICS_PUBSUB["txs_solved_weight"].labels(
@@ -222,8 +223,9 @@ class BasePrometheusExporter:
 
     async def _handle_protocol_job_completed(self, protocol: StratumProtocol) -> None:
         METRICS_PUBSUB["miner_completed_jobs"].labels(
-            miner_type=protocol.miner_type, miner_address=protocol.miner_address_str,
-            miner_id=protocol.miner_id
+            miner_type=protocol.miner_type,
+            miner_address=protocol.miner_address_str,
+            miner_id=protocol.miner_id,
         ).inc()
 
     async def _handle_protocol_miner_subscribed(

--- a/txstratum/protocol.py
+++ b/txstratum/protocol.py
@@ -191,10 +191,7 @@ class StratumProtocol(JSONRPCProtocol):
         now = txstratum.time.time()
 
         self.messages_in_transit[msgid] = MessageInTransit(
-            id=msgid,
-            method=method,
-            timeout=now + self.MESSAGE_TIMEOUT,
-            created_at=now
+            id=msgid, method=method, timeout=now + self.MESSAGE_TIMEOUT, created_at=now
         )
         self.send_request(method, params, msgid)
 

--- a/txstratum/protocol.py
+++ b/txstratum/protocol.py
@@ -75,7 +75,7 @@ class StratumProtocol(JSONRPCProtocol):
     RTT_ESTIMATOR_MESSAGE_TIMEOUT = (
         60  # in seconds, the maximum time to wait for an rtt message to be received
     )
-    RTT_CONFIDENCE_CONSTANT = 0.7
+    RTT_ALPHA_SLIDING_WINDOW = 0.7
 
     MIN_WEIGHT = 20.0  # minimum "difficulty" to assign to jobs
     MAX_WEIGHT = 60.0  # maximum "difficulty" to assign to jobs
@@ -109,7 +109,7 @@ class StratumProtocol(JSONRPCProtocol):
         self.rtt: float = 0.0
         self.rtt_estimator_task: Optional[Periodic] = None
         # Timestamp that the rtt message estimator was sent
-        self.rtt_time_message_sent: Optional[int] = None
+        self.rtt_time_message_sent: Optional[float] = None
 
         self._submitted_work: List[SubmittedWork] = []
 
@@ -173,7 +173,7 @@ class StratumProtocol(JSONRPCProtocol):
             self.miner_version = result
             now = txstratum.time.time()
             current_rtt = now - message.created_at
-            alpha = self.RTT_CONFIDENCE_CONSTANT
+            alpha = self.RTT_ALPHA_SLIDING_WINDOW
             self.rtt = (1 - alpha) * self.rtt + alpha * current_rtt
             self.rtt_time_message_sent = None
         else:


### PR DESCRIPTION
### Description

One possible improvement for our hashrate estimator is to consider the RTT value in the time to mine the job. Before we change the code to consider this rtt value, the first step is to calculate it and check if it influences the final hashrate estimation.

### Acceptance Criteria

- Add RTT method estimator.
- Store RTT value for each miner in prometheus.