### PR TITLE
feat: improve data collection of metrics

### DIFF
--- a/tests/fixtures/expected_prometheus_metrics.prom
+++ b/tests/fixtures/expected_prometheus_metrics.prom
@@ -40,6 +40,7 @@ txs_solved_weight_bucket{le="20.0",miner_type="cpuminer"} 1.0
 txs_solved_weight_bucket{le="21.0",miner_type="cpuminer"} 1.0
 txs_solved_weight_bucket{le="22.0",miner_type="cpuminer"} 1.0
 txs_solved_weight_bucket{le="23.0",miner_type="cpuminer"} 1.0
+txs_solved_weight_bucket{le="24.0",miner_type="cpuminer"} 1.0
 txs_solved_weight_bucket{le="25.0",miner_type="cpuminer"} 1.0
 txs_solved_weight_bucket{le="26.0",miner_type="cpuminer"} 1.0
 txs_solved_weight_bucket{le="27.0",miner_type="cpuminer"} 1.0
@@ -61,6 +62,7 @@ txs_timeout_weight_bucket{le="20.0"} 0.0
 txs_timeout_weight_bucket{le="21.0"} 0.0
 txs_timeout_weight_bucket{le="22.0"} 0.0
 txs_timeout_weight_bucket{le="23.0"} 0.0
+txs_timeout_weight_bucket{le="24.0"} 0.0
 txs_timeout_weight_bucket{le="25.0"} 0.0
 txs_timeout_weight_bucket{le="26.0"} 0.0
 txs_timeout_weight_bucket{le="27.0"} 0.0

--- a/tests/fixtures/expected_prometheus_metrics.prom
+++ b/tests/fixtures/expected_prometheus_metrics.prom
@@ -41,6 +41,11 @@ txs_solved_weight_bucket{le="21.0",miner_type="cpuminer"} 1.0
 txs_solved_weight_bucket{le="22.0",miner_type="cpuminer"} 1.0
 txs_solved_weight_bucket{le="23.0",miner_type="cpuminer"} 1.0
 txs_solved_weight_bucket{le="25.0",miner_type="cpuminer"} 1.0
+txs_solved_weight_bucket{le="26.0",miner_type="cpuminer"} 1.0
+txs_solved_weight_bucket{le="27.0",miner_type="cpuminer"} 1.0
+txs_solved_weight_bucket{le="28.0",miner_type="cpuminer"} 1.0
+txs_solved_weight_bucket{le="29.0",miner_type="cpuminer"} 1.0
+txs_solved_weight_bucket{le="30.0",miner_type="cpuminer"} 1.0
 txs_solved_weight_bucket{le="+Inf",miner_type="cpuminer"} 1.0
 txs_solved_weight_count{miner_type="cpuminer"} 1.0
 txs_solved_weight_sum{miner_type="cpuminer"} 18.65677715840935
@@ -57,6 +62,11 @@ txs_timeout_weight_bucket{le="21.0"} 0.0
 txs_timeout_weight_bucket{le="22.0"} 0.0
 txs_timeout_weight_bucket{le="23.0"} 0.0
 txs_timeout_weight_bucket{le="25.0"} 0.0
+txs_timeout_weight_bucket{le="26.0"} 0.0
+txs_timeout_weight_bucket{le="27.0"} 0.0
+txs_timeout_weight_bucket{le="28.0"} 0.0
+txs_timeout_weight_bucket{le="29.0"} 0.0
+txs_timeout_weight_bucket{le="30.0"} 0.0
 txs_timeout_weight_bucket{le="+Inf"} 0.0
 txs_timeout_weight_count 0.0
 txs_timeout_weight_sum 0.0

--- a/txstratum/prometheus.py
+++ b/txstratum/prometheus.py
@@ -47,13 +47,13 @@ METRICS_PUBSUB = {
     "txs_solved_weight": Histogram(
         "txs_solved_weight",
         "Txs solved histogram by tx weight",
-        buckets=(17, 18, 19, 20, 21, 22, 23, 25, 26, 27, 28, 29, 30, float("inf")),
+        buckets=(17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, float("inf")),
         labelnames=["miner_type"],
     ),
     "txs_timeout_weight": Histogram(
         "txs_timeout_weight",
         "Txs timeouts histogram by tx weight",
-        buckets=(17, 18, 19, 20, 21, 22, 23, 25, 26, 27, 28, 29, 30, float("inf")),
+        buckets=(17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, float("inf")),
     ),
     "txs_mining_time": Histogram(
         "txs_mining_time",

--- a/txstratum/prometheus.py
+++ b/txstratum/prometheus.py
@@ -47,13 +47,13 @@ METRICS_PUBSUB = {
     "txs_solved_weight": Histogram(
         "txs_solved_weight",
         "Txs solved histogram by tx weight",
-        buckets=(17, 18, 19, 20, 21, 22, 23, 25, float("inf")),
+        buckets=(17, 18, 19, 20, 21, 22, 23, 25, 26, 27, 28, 29, 30, float("inf")),
         labelnames=["miner_type"],
     ),
     "txs_timeout_weight": Histogram(
         "txs_timeout_weight",
         "Txs timeouts histogram by tx weight",
-        buckets=(17, 18, 19, 20, 21, 22, 23, 25, float("inf")),
+        buckets=(17, 18, 19, 20, 21, 22, 23, 25, 26, 27, 28, 29, 30, float("inf")),
     ),
     "txs_mining_time": Histogram(
         "txs_mining_time",

--- a/txstratum/protocol.py
+++ b/txstratum/protocol.py
@@ -378,6 +378,7 @@ class StratumProtocol(JSONRPCProtocol):
                     miner_type=self.miner_type,
                     hashrate=self.hashrate_ghs,
                     weight=job.get_weight(),
+                    hash=obj.hash_hex
                 )
                 self.blocks_found += 1
             else:
@@ -387,6 +388,7 @@ class StratumProtocol(JSONRPCProtocol):
                     miner_type=self.miner_type,
                     hashrate=self.hashrate_ghs,
                     weight=job.get_weight(),
+                    hash=obj.hash_hex
                 )
                 self.txs_solved += 1
 

--- a/txstratum/protocol.py
+++ b/txstratum/protocol.py
@@ -71,7 +71,7 @@ class StratumProtocol(JSONRPCProtocol):
 
     MIN_WEIGHT = 20.0  # minimum "difficulty" to assign to jobs
     MAX_WEIGHT = 60.0  # maximum "difficulty" to assign to jobs
-    INITIAL_WEIGHT = 30.0  # initial "difficulty" to assign to jobs, can raise or drop based on solvetimes
+    INITIAL_WEIGHT = 25.0  # initial "difficulty" to assign to jobs, can raise or drop based on solvetimes
     MAX_JOBS = 1000  # maximum number of jobs to keep in memory
 
     MESSAGE_TIMEOUT = 30  # in seconds, timeout for messages that are not answered
@@ -372,8 +372,22 @@ class StratumProtocol(JSONRPCProtocol):
             # to solve the block.
             self.manager.submit_solution(self, job, obj.get_struct_nonce())
             if obj.is_block:
+                self.log.info(
+                    "Block solved: ",
+                    miner_id=self.miner_id,
+                    miner_type=self.miner_type,
+                    hashrate=self.hashrate_ghs,
+                    weight=job.get_weight(),
+                )
                 self.blocks_found += 1
             else:
+                self.log.info(
+                    "Transaction solved: ",
+                    miner_id=self.miner_id,
+                    miner_type=self.miner_type,
+                    hashrate=self.hashrate_ghs,
+                    weight=job.get_weight(),
+                )
                 self.txs_solved += 1
 
         else:
@@ -422,7 +436,7 @@ class StratumProtocol(JSONRPCProtocol):
         for x in self._submitted_work:
             delta += x.dt
             logwork = sum_weights(logwork, x.weight)
-        # calculate hashrate in TH/s
+        # calculate hashrate in GH/s
         self.hashrate_ghs = 2 ** (logwork - log2(delta) - 30)
         self.set_current_weight(logwork - log2(delta) + log2(self.TARGET_JOB_TIME))
 

--- a/txstratum/protocol.py
+++ b/txstratum/protocol.py
@@ -378,7 +378,7 @@ class StratumProtocol(JSONRPCProtocol):
                     miner_type=self.miner_type,
                     hashrate=self.hashrate_ghs,
                     weight=job.get_weight(),
-                    hash=obj.hash_hex
+                    hash=obj.hash_hex,
                 )
                 self.blocks_found += 1
             else:
@@ -388,7 +388,7 @@ class StratumProtocol(JSONRPCProtocol):
                     miner_type=self.miner_type,
                     hashrate=self.hashrate_ghs,
                     weight=job.get_weight(),
-                    hash=obj.hash_hex
+                    hash=obj.hash_hex,
                 )
                 self.txs_solved += 1
 


### PR DESCRIPTION
### Acceptance Criteria

- Reduce initial weight for hashrate estimator because cpuminers were taking too long to mine their first job.
- Increase the quantity of buckets for `txs_solved_weight` and `txs_timeout_weight` metrics, so we can analyze better the distribution.
- Add log to collect data for the miner's hashrate that is solving each transaction and block.
- Fix log