### PR TITLE
feat: add CORS headers to all responses

### DIFF
--- a/txstratum/api.py
+++ b/txstratum/api.py
@@ -95,6 +95,8 @@ class App:
         self, request: web.Request, response: web.StreamResponse
     ) -> None:
         """Set CORS headers for all responses on_prepare."""
+        # We allow localhost:3000 because it's the host used by the desktop wallet
+        # so devs can test running their own tx mining service with it
         response.headers["Access-Control-Allow-Origin"] = "http://localhost:3000"
         response.headers["Access-Control-Allow-Methods"] = request.method
         response.headers[

--- a/txstratum/api.py
+++ b/txstratum/api.py
@@ -86,7 +86,17 @@ class App:
         self.app.router.add_post("/submit-job", self.submit_job)
         self.app.router.add_post("/cancel-job", self.cancel_job)
 
+        # Signal handler to add CORS headers when preparing the response
+        self.app.on_response_prepare.append(self.on_prepare)
+
         self.fix_invalid_timestamp: bool = fix_invalid_timestamp
+
+    async def on_prepare(self, request: web.Request, response: web.Response) -> None:
+        """Set CORS headers for all responses on_prepare."""
+        response.headers["Access-Control-Allow-Origin"] = "http://localhost:3000"
+        response.headers["Access-Control-Allow-Methods"] = request.method
+        response.headers["Access-Control-Allow-Headers"] = "x-prototype-version,x-requested-with,content-type"
+        response.headers["Access-Control-Max-Age"] = "604800"
 
     async def health(self, request: web.Request) -> web.Response:
         """Return the health check status for the tx-mining-service."""
@@ -187,6 +197,7 @@ class App:
         except NewJobRefused:
             self.log.debug("new-job-refused", data=data)
             return web.json_response({"error": "new-job-refused"}, status=503)
+
         return web.json_response(job.to_dict())
 
     def _get_job(self, uuid_hex: Optional[str]) -> TxJob:

--- a/txstratum/api.py
+++ b/txstratum/api.py
@@ -91,11 +91,15 @@ class App:
 
         self.fix_invalid_timestamp: bool = fix_invalid_timestamp
 
-    async def on_prepare(self, request: web.Request, response: web.Response) -> None:
+    async def on_prepare(
+        self, request: web.Request, response: web.StreamResponse
+    ) -> None:
         """Set CORS headers for all responses on_prepare."""
         response.headers["Access-Control-Allow-Origin"] = "http://localhost:3000"
         response.headers["Access-Control-Allow-Methods"] = request.method
-        response.headers["Access-Control-Allow-Headers"] = "x-prototype-version,x-requested-with,content-type"
+        response.headers[
+            "Access-Control-Allow-Headers"
+        ] = "x-prototype-version,x-requested-with,content-type"
         response.headers["Access-Control-Max-Age"] = "604800"
 
     async def health(self, request: web.Request) -> web.Response:
@@ -197,7 +201,6 @@ class App:
         except NewJobRefused:
             self.log.debug("new-job-refused", data=data)
             return web.json_response({"error": "new-job-refused"}, status=503)
-
         return web.json_response(job.to_dict())
 
     def _get_job(self, uuid_hex: Optional[str]) -> TxJob:


### PR DESCRIPTION
### Motivation

Developers who are implementing/testing new features in the hathor-core in a custom network might need to test things using the hathor-wallet. We currently have support for CORS headers (allowing localhost:3000 - the origin for the desktop wallet) in the hathor-core APIs but not in the tx mining service API.

### Acceptance Criteria

- Add CORS headers to all API responses.