### PR TITLE
fix: poetry build on docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-alpine as build
+FROM python:3.9-alpine AS build
 
 WORKDIR /code
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@
 [tool.poetry]
 name = "tx-mining-service"
 version = "0.14.0"
+package-mode = false
 description = "Service to mine transactions"
 authors = ["Hathor Team <contact@hathor.network>"]
 license = "MIT"


### PR DESCRIPTION
### Motivation

The docker build was failing because poetry v2 was released, requiring a change in our config. We now have to explicitly tell poetry that our project is not a package ([docs](https://python-poetry.org/docs/basic-usage/#operating-modes)).

### Acceptance Criteria

- Explicitly set `package-mode = false` in the `pyproject.toml`.
- Fix a minor warning in the `Dockerfile`.