### PR TITLE
chore: update python-hathorlib to v0.8.1

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -574,13 +574,13 @@ files = [
 
 [[package]]
 name = "hathorlib"
-version = "0.8.0"
+version = "0.8.1"
 description = "Hathor Network base objects library"
 optional = false
 python-versions = "<4,>=3.9"
 files = [
-    {file = "hathorlib-0.8.0-py3-none-any.whl", hash = "sha256:49323c17ecf8640bbf15b3b66f24dd6ebd12b2e0723e93767b5f59eca2993d09"},
-    {file = "hathorlib-0.8.0.tar.gz", hash = "sha256:02f7ee708de36046a709cdcc814e7ecf6eed4013b69ba00a4b6fce44e7d05a51"},
+    {file = "hathorlib-0.8.1-py3-none-any.whl", hash = "sha256:fd2d92ee130efdf11ff4c70018b05dd0816dbb27c97b0f6fc59664d5b90a6fff"},
+    {file = "hathorlib-0.8.1.tar.gz", hash = "sha256:19e2df2a1a2365f0e7faa1d7ade60e66f65ed2befe94c382499b92c282942c92"},
 ]
 
 [package.dependencies]
@@ -1166,4 +1166,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4.0"
-content-hash = "dceb64b489b651cdb8fa9da5bcf069b741c9da8c63ab80ee7dac0314901efb7e"
+content-hash = "c8f1666d8899b0474fe744a407be5b819da847ef7b3f3ae83a3488be780036d6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@
 
 [tool.poetry]
 name = "tx-mining-service"
-version = "0.16.0"
+version = "0.16.1"
 package-mode = false
 description = "Service to mine transactions"
 authors = ["Hathor Team <contact@hathor.network>"]
@@ -24,7 +24,7 @@ structlog = "~22.3.0"
 prometheus-client = "^0.9.0"
 idna_ssl = "^1.1.0"
 asynctest = "^0.13.0"
-hathorlib = {version = "^0.8.0", extras = ["client"]}
+hathorlib = {version = "^0.8.1", extras = ["client"]}
 dataclasses = {version = "^0.8", python = ">=3.6,<3.7"}
 python-healthchecklib = "^0.1.0"
 


### PR DESCRIPTION
### Acceptance Criteria

- Update hathorlib to v0.8.1
- Bump version to v16.0.1