### PR TITLE
fix: use calculate_hash for job uuid to prevent different txs with the same uuid

### DIFF
--- a/txstratum/jobs.py
+++ b/txstratum/jobs.py
@@ -60,7 +60,9 @@ class TxJob:
         """
         self._tx: BaseTransaction = tx_or_block_from_bytes(data)
 
-        self.uuid: bytes = hashlib.sha256(self._tx.get_mining_header_without_nonce()).digest()
+        self.uuid: bytes = hashlib.sha256(
+            self._tx.get_mining_header_without_nonce()
+        ).digest()
         self.add_parents: bool = add_parents
         self.propagate: bool = propagate
         self.timeout: Optional[float] = timeout

--- a/txstratum/jobs.py
+++ b/txstratum/jobs.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import enum
+import hashlib
 import uuid
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set
@@ -59,7 +60,7 @@ class TxJob:
         """
         self._tx: BaseTransaction = tx_or_block_from_bytes(data)
 
-        self.uuid: bytes = self._tx.get_funds_hash()
+        self.uuid: bytes = hashlib.sha256(self._tx.get_mining_header_without_nonce()).digest()
         self.add_parents: bool = add_parents
         self.propagate: bool = propagate
         self.timeout: Optional[float] = timeout

--- a/txstratum/jobs.py
+++ b/txstratum/jobs.py
@@ -4,7 +4,6 @@
 # LICENSE file in the root directory of this source tree.
 
 import enum
-import hashlib
 import uuid
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set
@@ -60,9 +59,7 @@ class TxJob:
         """
         self._tx: BaseTransaction = tx_or_block_from_bytes(data)
 
-        self.uuid: bytes = hashlib.sha256(
-            self._tx.get_mining_header_without_nonce()
-        ).digest()
+        self.uuid: bytes = self._tx.calculate_hash()
         self.add_parents: bool = add_parents
         self.propagate: bool = propagate
         self.timeout: Optional[float] = timeout


### PR DESCRIPTION
### Motivation

In the wallet lib integration tests I was able to correctly build and mine transactions with nano header for `initialize` and `bet` methods (using the Bet blueprint) but the `set_result` tx was always failing.

The error was that the transaction mining service identified the `set_result` tx as the same as the `initialize` tx because both didn't have inputs/outputs/tokens and we were using `tx. get_funds_hash` for the job uuid, so it was just returning the same nonce, which was wrong.

### Acceptance Criteria

- Use `calculate_hash ` instead of `get_funds_hash`.