### PR TITLE
chore: update python-hathorlib to v0.9.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -574,13 +574,13 @@ files = [
 
 [[package]]
 name = "hathorlib"
-version = "0.8.1"
+version = "0.9.0"
 description = "Hathor Network base objects library"
 optional = false
 python-versions = "<4,>=3.9"
 files = [
-    {file = "hathorlib-0.8.1-py3-none-any.whl", hash = "sha256:fd2d92ee130efdf11ff4c70018b05dd0816dbb27c97b0f6fc59664d5b90a6fff"},
-    {file = "hathorlib-0.8.1.tar.gz", hash = "sha256:19e2df2a1a2365f0e7faa1d7ade60e66f65ed2befe94c382499b92c282942c92"},
+    {file = "hathorlib-0.9.0-py3-none-any.whl", hash = "sha256:fee191a709949bfc3fa67ef0d01977887817f752808385cab2913197c582811a"},
+    {file = "hathorlib-0.9.0.tar.gz", hash = "sha256:98ead66f252c143fd5e9171d025a4c36d0e8edd83aca30665f1fb04bb0f1dcbb"},
 ]
 
 [package.dependencies]
@@ -1166,4 +1166,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4.0"
-content-hash = "c8f1666d8899b0474fe744a407be5b819da847ef7b3f3ae83a3488be780036d6"
+content-hash = "cb6806cf5baa8dd88cd7bb00d883c46418eb8d295f849153f474b1b6be9bc064"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@
 
 [tool.poetry]
 name = "tx-mining-service"
-version = "0.16.2"
+version = "0.17.0"
 package-mode = false
 description = "Service to mine transactions"
 authors = ["Hathor Team <contact@hathor.network>"]
@@ -24,7 +24,7 @@ structlog = "~22.3.0"
 prometheus-client = "^0.9.0"
 idna_ssl = "^1.1.0"
 asynctest = "^0.13.0"
-hathorlib = {version = "^0.8.1", extras = ["client"]}
+hathorlib = {version = "^0.9.0", extras = ["client"]}
 dataclasses = {version = "^0.8", python = ">=3.6,<3.7"}
 python-healthchecklib = "^0.1.0"
 


### PR DESCRIPTION
### Acceptance Criteria

- Update hathorlib to `v0.9.0`
- Bump package to `v0.17.0`